### PR TITLE
Move OpenID Connect docs URL

### DIFF
--- a/_pages/openid_connect.md
+++ b/_pages/openid_connect.md
@@ -1,5 +1,6 @@
 ---
 title: OpenID Connect
+permalink: /openid-connect
 ---
 
 <div class="usa-alert usa-alert-warning">


### PR DESCRIPTION
The top-level directory uses dashes (`identity-dev-docs`) so I think the other pages should use dashes too