### PR TITLE
Add notranslate meta tag

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="google" value="notranslate">
 
     <title>{% if page.title %}{{ site.title }} | {{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
     <meta name="description" content="{{ site.description }}">


### PR DESCRIPTION
Hotfix to prevent Chrome offering to translate the `/certs/` page into Polish. I'll try to identify what the specific cause of it is, but since we do not offer the dev docs site in other languages at this point, the meta tag should not harm anything for now.