### PR TITLE
Fix primary navigation links at Federalist Preview URLs.

### DIFF
--- a/_includes/nav/item.html
+++ b/_includes/nav/item.html
@@ -3,7 +3,13 @@
 {% else -%}
   {% assign is_current_page = false -%}
 {% endif -%}
-<a href="{{ include.link.href }}" class="{% if is_current_page %}usa-current{% endif %}">
+{% assign first_character = include.link.href | slice: 0 -%}
+{% if first_character == '#' -%}
+  {% assign href = include.link.href -%}
+{% else -%}
+  {% assign href = include.link.href | relative_url -%}
+{% endif -%}
+<a href="{{ href }}" class="{% if is_current_page %}usa-current{% endif %}">
   <span>
     {{ include.link.text | smartify }}
   </span>


### PR DESCRIPTION
Introduced in #67, this PR fixes an issue where the navigation links at Federalist preview URLs weren’t built correctly. 

The issue can be observed on [the Federalist preview of #67](https://federalist-proxy.app.cloud.gov/preview/18f/identity-dev-docs/login-style-guide/), as compared to [the Federalist preview of this PR](https://federalist-proxy.app.cloud.gov/preview/18f/identity-dev-docs/fix-header-links-in-preview/). Since production is always served at the root URL, this issue and the fix do not affect production.