### PR TITLE
Update identity-style-guide to latest.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "identity-style-guide": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/identity-style-guide/-/identity-style-guide-1.0.1.tgz",
-      "integrity": "sha512-axDAz21Z8eFEQU2jPIPrw4+MpxYbFSBM3gq/fYfHo5Ip8Pxw9yUSTncNwQVFULu9ot4GoUg/StIsjGN1xlmg2Q=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/identity-style-guide/-/identity-style-guide-1.1.0.tgz",
+      "integrity": "sha512-DEKswFE+n4wOSsA08DnQxZpWui2Je48GufYW4BB/xH8nkTE+fgFq7NXgMF/w04up0Z6nZSb2LmlNfvMsUgu99Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   },
   "homepage": "https://github.com/18F/identity-dev-docs#readme",
   "dependencies": {
-    "identity-style-guide": "^1.0.1"
+    "identity-style-guide": "^1.1.0"
   }
 }


### PR DESCRIPTION
Includes: 

- Adds a max-width to list items (https://github.com/18F/identity-style-guide/issues/54).
- Clearer styles for code blocks (https://github.com/18F/identity-style-guide/issues/56).
- Improved focus styles (https://github.com/18F/identity-style-guide/issues/57).

You can check out the changes on the [Federalist preview](https://federalist-proxy.app.cloud.gov/preview/18f/identity-dev-docs/upgrade-style-guide/).