### PR TITLE
Updated NIST 800-63-2 References to NIST 800-63-3

### DIFF
--- a/_pages/attributes.md
+++ b/_pages/attributes.md
@@ -1,7 +1,7 @@
 ---
 title: User attributes
 lead: >
-  login.gov user accounts are either proofed (IAL2) or (IAL1), corresponding to <a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63-3.pdf">NIST 800-63-3</a> Identity Assurance Level (IAL).
+  login.gov user accounts are either proofed (IAL2) or self-asserted (IAL1), corresponding to <a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63-3.pdf">NIST 800-63-3</a> Identity Assurance Level (IAL).
 ---
 
 Here are the possible attributes that can be requested at a given IAL. This table contains the available user attributes, the IAL they are associated with, and how they can be accessed in OpenID Connect and SAML.

--- a/_pages/attributes.md
+++ b/_pages/attributes.md
@@ -1,7 +1,7 @@
 ---
 title: User attributes
 lead: >
-  login.gov user accounts are either proofed (LOA3) or not (LOA1), corresponding to <a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63-2.pdf">NIST 800-63-2</a> levels of assurance (LOA).
+  login.gov user accounts are either proofed (LOA3) or not (LOA1), corresponding to <a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63-3.pdf">NIST 800-63-3</a> levels of assurance (LOA).
 ---
 
 Here are the possible attributes that can be requested at a given LOA. This table contains the available user attributes, the LOA they are associated with, and how they can be accessed in OpenID Connect and SAML.

--- a/_pages/attributes.md
+++ b/_pages/attributes.md
@@ -1,12 +1,12 @@
 ---
 title: User attributes
 lead: >
-  login.gov user accounts are either proofed (LOA3) or not (LOA1), corresponding to <a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63-3.pdf">NIST 800-63-3</a> levels of assurance (LOA).
+  login.gov user accounts are either proofed (IAL2) or (IAL1), corresponding to <a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63-3.pdf">NIST 800-63-3</a> Identity Assurance Level (IAL).
 ---
 
-Here are the possible attributes that can be requested at a given LOA. This table contains the available user attributes, the LOA they are associated with, and how they can be accessed in OpenID Connect and SAML.
+Here are the possible attributes that can be requested at a given IAL. This table contains the available user attributes, the IAL they are associated with, and how they can be accessed in OpenID Connect and SAML.
 
-| Attribute | LOA1 | LOA3 | OpenID Connect | SAML |
+| Attribute | IAL1 | IAL2 | OpenID Connect | SAML |
 | --------- | ---- | ---- | -------------- | ---- |
 | **UUID**<br>The user's [universally unique identifier](https://en.wikipedia.org/wiki/Universally_unique_identifier). | <img src="{{ site.baseurl }}/assets/img/check.svg" alt="checkmark"> | <img src="{{ site.baseurl }}/assets/img/check.svg" alt="checkmark"> | `sub` (string) | `uuid` |
 | **Email**<br>The user's email address. | <img src="{{ site.baseurl }}/assets/img/check.svg" alt="checkmark"> | <img src="{{ site.baseurl }}/assets/img/check.svg" alt="checkmark"> | `email` (string)<br><br>Requires the `email` scope. | `email` |


### PR DESCRIPTION
NIST 800-63-2 has been superseded by NIST 800-63-3 as of June 22, 2017.