### PR TITLE
Remove Java and Python example SPs

### DIFF
--- a/_pages/saml.md
+++ b/_pages/saml.md
@@ -383,7 +383,5 @@ Node.js
 
 The login.gov team has created example clients to speed up your development, all open source in the public domain.
 
-- [Java / Spring](https://github.com/18F/identity-saml-java)
 - [Ruby / Sinatra](https://github.com/18F/identity-saml-sinatra)
 - [Ruby / Rails](https://github.com/18F/identity-saml-rails)
-- [Python / Flask](https://github.com/18F/identity-saml-python)


### PR DESCRIPTION
These are old and unmaintained, removing references from them in our developer documentation