### PR TITLE
Fix broken link to OIDC on homepage

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -19,7 +19,7 @@ layout: home
 
 - [Understand our flow]({{ site.baseurl }}/overview).
 - Determine your application needs, like the level of proofing and [user attributes]({{ site.baseurl }}/attributes) that will be requested.
-- Select between OpenID Connect (OIDC)]({{ site.baseurl }}/oidc) or [SAML protocol]({{ site.baseurl }}/saml) implementation protocols. Please note that we recommend OIDC.
+- Select between [OpenID Connect (OIDC)]({{ site.baseurl }}/oidc) or [SAML protocol]({{ site.baseurl }}/saml) implementation protocols. Please note that we recommend OIDC.
 - Configure your app. We have [implementation guides]({{ site.baseurl }}/oidc) and example apps to get you up and running quickly.
 - [Get added to our test sandbox encvironment](https://share.hsforms.com/16DIoo--rTU2xbNW1MShkBg3ak9e)
 - [Register your app in the sandbox dashboard and start testing]({{ site.baseurl }}/testing).

--- a/spec/page.md_spec.rb
+++ b/spec/page.md_spec.rb
@@ -4,6 +4,10 @@ Dir.glob('_site/**/*.html') do |page|
   RSpec.describe page do
     let(:doc) { Nokogiri::HTML(File.new(page.to_s)) }
 
+    it 'does not have broken Markdown links' do
+      expect(doc.to_s).to_not include(')]')
+    end
+
     it 'links to valid headings' do
       expect(doc).to link_to_valid_headers
     end


### PR DESCRIPTION
Before
<img width="154" alt="Screen Shot 2020-01-29 at 1 42 39 PM" src="https://user-images.githubusercontent.com/458784/73386780-73e66880-429d-11ea-8b39-3fe09998eb12.png">


After
<img width="305" alt="Screen Shot 2020-01-29 at 1 43 18 PM" src="https://user-images.githubusercontent.com/458784/73386791-76e15900-429d-11ea-875a-e83747cbb36a.png">
