### PR TITLE
fix 404 problem

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -17,13 +17,13 @@ layout: home
 
 # Get started...
 
-- [Understand our flow]({{ site.baseurl }}/overview).
-- Determine your application needs, like the level of proofing and [user attributes]({{ site.baseurl }}/attributes) that will be requested.
-- Select between [OpenID Connect (OIDC)]({{ site.baseurl }}/oidc) or [SAML protocol]({{ site.baseurl }}/saml) implementation protocols. Please note that we recommend OIDC.
-- Configure your app. We have [implementation guides]({{ site.baseurl }}/oidc) and example apps to get you up and running quickly.
+- [Understand our flow]({{ site.baseurl }}/overview/).
+- Determine your application needs, like the level of proofing and [user attributes]({{ site.baseurl }}/attributes/) that will be requested.
+- Select between [OpenID Connect (OIDC)]({{ site.baseurl }}/oidc/) or [SAML protocol]({{ site.baseurl }}/saml/) implementation protocols. Please note that we recommend OIDC.
+- Configure your app. We have [implementation guides]({{ site.baseurl }}/oidc/) and example apps to get you up and running quickly.
 - [Get added to our test sandbox environment](https://share.hsforms.com/16DIoo--rTU2xbNW1MShkBg3ak9e)
-- [Register your app in the sandbox dashboard and start testing]({{ site.baseurl }}/testing).
+- [Register your app in the sandbox dashboard and start testing]({{ site.baseurl }}/testing/).
 - Let us know when you are ready to go live and our [partners@login.gov](mailto:partners@login.gov) will help you promote the application to production. We will check you against our production checklist to ensure your application is good to go to production from an administrative and technical standpoint.
-- Be sure to read the [FAQ]({{ site.baseurl }}/faq) for answers to the most common questions.
+- Be sure to read the [FAQ]({{ site.baseurl }}/faq/) for answers to the most common questions.
 
 </section>

--- a/_pages/oidc.md
+++ b/_pages/oidc.md
@@ -54,7 +54,7 @@ Consistent with the specification, login.gov provides a JSON endpoint for OpenID
 The authorization endpoint handles authentication and authorization of a user. To present the login.gov authorization page to a user, direct them to the `/openid_connect/authorize` endpoint with the following parameters:
 
 * **acr_values**
-  The Authentication Context Class Reference values used to specify the LOA (level of assurance) of an account, either LOA1 or LOA3. This and the `scope` determine which [user attributes]({{ site.baseurl }}/attributes) will be available in the [user info response](#user-info-response). The possible parameter values are:
+  The Authentication Context Class Reference values used to specify the LOA (level of assurance) of an account, either LOA1 or LOA3. This and the `scope` determine which [user attributes]({{ site.baseurl }}/attributes/) will be available in the [user info response](#user-info-response). The possible parameter values are:
     - `http://idmanagement.gov/ns/assurance/loa/1`
     - `http://idmanagement.gov/ns/assurance/loa/3`
 
@@ -89,7 +89,7 @@ The authorization endpoint handles authentication and authorization of a user. T
   The URI login.gov will redirect to after a successful authorization.
 
 * **scope**
-  A space-separated string of the scopes being requested. The authorization page will display the list of attributes being requested from the user. Applications should aim to request the fewest [user attributes]({{ site.baseurl }}/attributes) and smallest scope needed. Possible values are: `openid`, `address`, `email`, `phone`, `profile:birthdate`, `profile:name`, `profile`, and `social_security_number`
+  A space-separated string of the scopes being requested. The authorization page will display the list of attributes being requested from the user. Applications should aim to request the fewest [user attributes]({{ site.baseurl }}/attributes/) and smallest scope needed. Possible values are: `openid`, `address`, `email`, `phone`, `profile:birthdate`, `profile:name`, `profile`, and `social_security_number`
 
 * **state**
   A unique value at least 32 characters in length used for maintaining state between the request and the callback. This value will be returned to the client on a successful authorization.
@@ -237,7 +237,7 @@ Here's an example token response:
 The **id_token** contains the following claims:
 
 * **iss** (string) — The issuer of the response, which will be the URL of the login.gov IdP, for example: `https://idp.int.identitysandbox.gov`
-* **sub** (string) — The subject identifier, the UUID of the login.gov user (see [user attributes]({{ site.baseurl }}/attributes)).
+* **sub** (string) — The subject identifier, the UUID of the login.gov user (see [user attributes]({{ site.baseurl }}/attributes/)).
 * **aud** (string) — The audience, which will be the `client_id`.
 * **acr** (string) — The Authentication Context Class Reference value of the returned claims, from the original [authorization request](#authorization).
 * **at_hash** (string) — The access token hash, a URL-safe base-64 encoding of the left 128 bits of the SHA256 of the `access_token` value. Provided so the client can verify the `access_token` value.
@@ -268,7 +268,7 @@ Here's an example decoded **id_token**:
 
 # User info
 
-The user info endpoint is used to retrieve [user attributes]({{ site.baseurl }}/attributes). Clients use the `access_token` from the [token response](#token-response) as a bearer token in the [HTTP Authorization header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization). To request attributes, send an HTTP GET request to the `/api/openid_connect/userinfo` endpoint, for example:
+The user info endpoint is used to retrieve [user attributes]({{ site.baseurl }}/attributes/). Clients use the `access_token` from the [token response](#token-response) as a bearer token in the [HTTP Authorization header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization). To request attributes, send an HTTP GET request to the `/api/openid_connect/userinfo` endpoint, for example:
 
 ```
 GET https://idp.int.identitysandbox.gov/api/openid_connect/userinfo
@@ -277,7 +277,7 @@ Authorization: Bearer hhJES3wcgjI55jzjBvZpNQ
 
 ## User info response
 
-The user info response will be a JSON object containing [user attributes]({{ site.baseurl }}/attributes). login.gov supports some of the [standard claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) from OpenID Connect 1.0. In addition to the user attributes, the following information will also be present:
+The user info response will be a JSON object containing [user attributes]({{ site.baseurl }}/attributes/). login.gov supports some of the [standard claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) from OpenID Connect 1.0. In addition to the user attributes, the following information will also be present:
 
 * **iss** (string)
   The issuer of the response, which will be the URL of the login.gov IdP, for example: `https://idp.int.identitysandbox.gov`

--- a/_pages/overview.md
+++ b/_pages/overview.md
@@ -7,10 +7,10 @@ lead: >
 Login.gov is a FedRAMP moderate approved multifactor authentication and identity proofing platform that makes online interactions with the U.S. government simple, efficient and intuitive.
 
 <h2>Integration flow</h2>
-* Once a [service provider configuration](/#service-provider-configuration) is provided in one of login.gov's environments, users start at your application and are redirected back to login.gov via [OIDC]({{ site.baseurl }}/oidc) or [SAML]({{ site.baseurl }}/saml) protocols.
+* Once a [service provider configuration](/#service-provider-configuration) is provided in one of login.gov's environments, users start at your application and are redirected back to login.gov via [OIDC]({{ site.baseurl }}/oidc/) or [SAML]({{ site.baseurl }}/saml/) protocols.
 * Your application request will determine if the request will be processed as just an authentication request at NIST Identity Assurance Level 1 (IAL1) or as an identity proofed event at NIST Identity Assurance Level 2 (IAL2).
 * New users will either create an account corresponding to the identity assurance level requested (IAL1/IAL2) and returning users will present their existing login.gov credentials to reauthenticate into login.gov. If a user is new to your application they will consent to their information being shared with your application.
-* Upon successful completion of the account creation or authentication, users will be redirected back to your application with the [user attributes]({{ site.baseurl }}/attributes) that correspond to their user level.
+* Upon successful completion of the account creation or authentication, users will be redirected back to your application with the [user attributes]({{ site.baseurl }}/attributes/) that correspond to their user level.
 * With the attributes provided by login.gov, your application will handle authorization of the user and assign roles and permissions.
 
 

--- a/_pages/saml.md
+++ b/_pages/saml.md
@@ -33,7 +33,7 @@ sidenav:
 ---
 
 <div class="usa-alert usa-alert-warning">
-  <div class="usa-alert-body">We strongly recommend choosing <a href="{{ site.baseurl }}/oidc">OpenID Connect</a> over SAML due to its modern, API-centric design and support for native mobile applications.
+  <div class="usa-alert-body">We strongly recommend choosing <a href="{{ site.baseurl }}/oidc/">OpenID Connect</a> over SAML due to its modern, API-centric design and support for native mobile applications.
   </div>
 </div>
 
@@ -155,7 +155,7 @@ The supported LOA levels area, place one of these values inside a `<saml:AuthnCo
   - `http://idmanagement.gov/ns/assurance/loa/1`
   - `http://idmanagement.gov/ns/assurance/loa/3`
 
-To request specific attributes, list them (comma-separated) as the query parameter for `http://idmanagement.gov/ns/requested_attributes?ReqAttr=`. See the [user attributes]({{ site.baseurl }}/attributes) for the list of attributes that can be requested.
+To request specific attributes, list them (comma-separated) as the query parameter for `http://idmanagement.gov/ns/requested_attributes?ReqAttr=`. See the [user attributes]({{ site.baseurl }}/attributes/) for the list of attributes that can be requested.
 
 An LOA3 request for email, phone, first name, last name, and SSN might look like:
 


### PR DESCRIPTION
fixed trailing slash issue that is causing federalist to 404 on many links off of https://developers.login.gov/ and other pages.