### PR TITLE
Patch button spacing issue in design-guidelines.md

### DIFF
--- a/_pages/design-guidelines.md
+++ b/_pages/design-guidelines.md
@@ -29,7 +29,7 @@ From the [U.S. Web Design System](https://designsystem.digital.gov/components/bu
 
 ### Sample buttons
 
-<button class="usa-button usa-button--big">Sign in</button> <button class="usa-button ">Sign in</button> <button class="usa-button usa-button--outline">Sign in</button>
+<button class="usa-button usa-button--big">Sign in</button> <button class="usa-button margin-y-2">Sign in</button> <button class="usa-button usa-button--outline">Sign in</button>
 
 
 ```


### PR DESCRIPTION
**Why:** On mobile, there is lack of space between sample buttons (They gotta breathe)

**How:** Add `margin-y-2` to create spacing on top and bottom

## Before
![dev-docs-buttons-before](https://user-images.githubusercontent.com/6327082/74569771-d350a380-4f40-11ea-83b1-26d7a209eb3e.png)

## After
![dev-docs-buttons-after](https://user-images.githubusercontent.com/6327082/74569769-d2b80d00-4f40-11ea-96ed-f5bdcca10b8c.png)

