### PR TITLE
Capitalize "L" where login.gov starts a sentence

### DIFF
--- a/_pages/design-guidelines.md
+++ b/_pages/design-guidelines.md
@@ -91,10 +91,10 @@ Users need a clearly marked button to sign out. After a user has signed in to yo
 When you first integrate with login.gov you may want to indicate to your users that your application uses login.gov for authentication or proofing. If you decide to do so, please use the following language:
 
 ### What is login.gov?
-login.gov is a service that offers secure and private online access to government programs, such as federal benefits, services and applications. With a login.gov account, you can sign into multiple government websites with the same email address and password.
+Login.gov is a service that offers secure and private online access to government programs, such as federal benefits, services and applications. With a login.gov account, you can sign into multiple government websites with the same email address and password.
 
 ### Why is `YOUR APPLICATION` using login.gov?
-login.gov uses two-factor authentication, and stronger passwords, that meet new National Institute of Standards of Technology requirements for secure validation and verification. By using login.gov, you’ll get an extra layer of security to help protect your account against password compromises.
+Login.gov uses two-factor authentication, and stronger passwords, that meet new National Institute of Standards of Technology requirements for secure validation and verification. By using login.gov, you’ll get an extra layer of security to help protect your account against password compromises.
 
 ## Agency logo guidelines
 We will publish your agency logo on login.gov to help users understand that partnership between the services. Please follow these guidelines when submitting a logo:


### PR DESCRIPTION
As far as I understand, and according to https://design.login.gov/content/ the "l" for login.gov should be capitalized. I updated this under these two sections "What is login.gov?" and "Why is `YOUR APPLICATION` using login.gov?"