### PR TITLE
Fix "service provider configuration" link to in-page heading

### DIFF
--- a/_pages/overview.md
+++ b/_pages/overview.md
@@ -8,7 +8,7 @@ Login.gov is a FedRAMP moderate approved multifactor authentication and identity
 
 ## Integration flow
 
-* Once a [service provider configuration](/#service-provider-configuration) is provided in one of login.gov's environments, users start at your application and are redirected back to login.gov via [OIDC]({{ site.baseurl }}/oidc/) or [SAML]({{ site.baseurl }}/saml/) protocols.
+* Once a [service provider configuration](#service-provider-configuration) is provided in one of login.gov's environments, users start at your application and are redirected back to login.gov via [OIDC]({{ site.baseurl }}/oidc/) or [SAML]({{ site.baseurl }}/saml/) protocols.
 * Your application request will determine if the request will be processed as just an authentication request at NIST Identity Assurance Level 1 (IAL1) or as an identity proofed event at NIST Identity Assurance Level 2 (IAL2).
 * New users will either create an account corresponding to the identity assurance level requested (IAL1/IAL2) and returning users will present their existing login.gov credentials to reauthenticate into login.gov. If a user is new to your application they will consent to their information being shared with your application.
 


### PR DESCRIPTION
**Why**: Currently links to homepage, which does not contain the relevant information about service provider configuration.