### PR TITLE
Add production deploy article

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,7 +1,7 @@
 primary:
   - text: Getting Started
     href: /
-  - text: Integration flow
+  - text: Integration
     href: /overview/
   - text: OpenID Connect
     href: /oidc/
@@ -15,5 +15,7 @@ primary:
     href: /testing/
   - text: Security
     href: /security-events/
+  - text: Production
+    href: /Production/
   - text: FAQ
     href: /faq/

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -16,6 +16,6 @@ primary:
   - text: Security
     href: /security-events/
   - text: Production
-    href: /Production/
+    href: /production/
   - text: FAQ
     href: /faq/

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -13,9 +13,9 @@ primary:
     href: /design-guidelines/
   - text: Testing
     href: /testing/
-  - text: Security
-    href: /security-events/
   - text: Production
     href: /production/
+  - text: Security
+    href: /security-events/
   - text: FAQ
     href: /faq/

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,5 +1,5 @@
 primary:
-  - text: Getting Started
+  - text: Get Started
     href: /
   - text: Integration
     href: /overview/

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -1,0 +1,79 @@
+---
+title: Production deployment
+lead: >
+  Once you’ve tested your integration in our sandbox environment, you can request deployment to the Login.gov production environment.
+redirect_from:
+  - /production-deployment/
+sidenav:
+  - text: Production endpoints
+    href: "#production-endpoints"
+  - text: Deployments
+    href: "#deployments"
+  - text: Confirm IAA
+    href: "#confirm-iaa"
+  - text: Staging environment
+    href: "#staging-environment"
+  - text: Production configuration
+    href: "#production-configuration"
+  - text: Request deployment
+    href: "#request-deployment"
+  - text: Deploying changes
+    href: "#deploying-changes"
+---
+
+
+## Production endpoints
+
+Our integration documentation includes endpoint urls for our sandbox environment https://idp.int.identitysandbox.gov/. Our production environment is located at https://secure.login.gov/. The URL path to each endpoint remains the same. Only the domain will change. For example, the authorization endpoint will change as follows:
+* OpenID Connect - [https://secure.login.gov/openid_connect/authorize](https://secure.login.gov/openid_connect/authorize)
+* SAML - [https://secure.login.gov/api/saml/auth2020](https://secure.login.gov/api/saml/auth2020)
+
+Please be aware that the IDP certificate (X509Certificate) in the Production environment is different from the IDP certificate in the sandbox environment. The Production IDP certificates can be found here:
+* OpenID Connect - [https://secure.login.gov/api/openid_connect/certs](https://secure.login.gov/api/openid_connect/certs)
+* SAML - [https://secure.login.gov/api/saml/metadata2020](https://secure.login.gov/api/saml/metadata2020)
+
+## Deployments
+
+All changes to integrations between login.gov and your application must be reviewed and deployed. We ask for 1 week notice for new integrations and changes to existing integrations. Regular deployments occur every Thursday by the close of business day. If the regular deployment occurs on a holiday, then it will be completed the following Monday.
+
+## Confirm IAA
+
+You must have a signed IAA (Inter Agency Agreement) in order to deploy to production. You will need to provide the IAA Number this application will be billed under. The IAA number format will include GTC-Order-ModNumber (Example: LGABCFY210001-0001-0000).
+
+Please reach out to your agency IAA contact if you have any questions. If your agency does not already have an IAA, then ask your agency contact to reach out to [partners@login.gov](mailto:partners@login.gov) to begin the IAA process which can take up to 6 weeks to complete.
+
+## Staging environment
+
+Many partners choose to create a separate Staging app in our sandbox environment for testing their staging environment, because changes take effect immediately without waiting for review and deployment.
+
+If you are testing an IAL2 integration, then we also offer a Staging environment for limited testing. You must have a signed IAA in order to deploy to Staging. Our Staging environment is approved for PII which can be useful in certain test cases. However, any configuration changes in the Staging environment must be reviewed and deployed.
+
+If you wish to deploy an application to our Staging environment, then create a “Staging” configuration app like the “Production” configuration app described in the next section.
+
+## Production configuration
+
+Before you can deploy your application to the production environment, you will need to create a separate app on our dashboard that contains your production certificate, urls and logo. Here are the steps to complete your production configuration app:
+1. Create a new app on the dashboard https://dashboard.int.identitysandbox.gov/
+2. Enter a Friendly Name with "Production" in the title
+3. Enter the production urls and configuration into the app
+
+PLEASE NOTE: The following items are required to promote your app to production:
+
+* All production urls should have .gov .mil or a dedicated .com address and point to an ATO'd environment.
+* If your app does not have a logo, then you will need to upload one. You can find the [logo guidelines here](https://developers.login.gov/design-guidelines/#agency-logo-guidelines).
+* If this is an SAML integration (Not OpenID Connect), then please ensure that:
+  * Assertion Consumer Logout Service URL is defined.
+  * SAML Assertion Encryption is enabled.
+    * If you are using a service which does not support SAML encryption, then please send a message to [partners@login.gov](mailto:partners@login.gov) for further guidance.
+
+## Request deployment
+
+Once you have:
+1. [Received a signed IAA number](#confirm-iaa)
+2. [Created a production configuration](#production-configuration)
+
+Please submit the [login.gov production integration request form](https://share.hsforms.com/1UTxHGOu2Q0SVyz9ulknZGw3ak9e){:target='_blank'}.
+
+## Deploying changes
+
+Please update your production configuration app in the dashboard and test the changes you wish to deploy. After you have confirmed the change, then send a message to [partners@login.gov](mailto:partners@login.gov) requesting a production deployment. Please include a brief description of the change and the url to your production configuration app in the dashboard.

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -53,7 +53,7 @@ If you wish to deploy an application to our Staging environment, then create a â
 ## Production configuration
 
 Before you can deploy your application to the production environment, you will need to create a separate app on our dashboard that contains your production certificate, urls and logo. Here are the steps to complete your production configuration app:
-1. Create a new app on the dashboard https://dashboard.int.identitysandbox.gov/
+1. Create a new app on the dashboard <https://dashboard.int.identitysandbox.gov/>
 2. Enter a Friendly Name with "Production" in the title
 3. Enter the production urls and configuration into the app
 

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -44,7 +44,7 @@ Please reach out to your agency IAA contact if you have any questions. If your a
 
 ## Staging environment
 
-Many partners choose to create a separate Staging app in our sandbox environment for testing their staging environment, because changes take effect immediately without waiting for review and deployment.
+Many partners choose to create a separate staging app in our sandbox environment for testing their staging environment, because changes take effect immediately without waiting for review and deployment.
 
 If you are testing an IAL2 integration, then we also offer a Staging environment for limited testing. You must have a signed IAA in order to deploy to Staging. Our Staging environment is approved for PII which can be useful in certain test cases. However, any configuration changes in the Staging environment must be reviewed and deployed.
 

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -18,7 +18,7 @@ sidenav:
   - text: Request deployment
     href: "#request-deployment"
   - text: Changes to production applications
-    href: "#production-changes"
+    href: "#changes-to-production-applications"
 ---
 
 
@@ -77,4 +77,3 @@ Please submit the [login.gov production integration request form](https://share.
 ## Changes to production applications
 
 Please update your production configuration app in the dashboard and test the changes you wish to deploy. After you have confirmed the change, then please submit the [login.gov integration change request form](https://share.hsforms.com/1HF9Q6UNARaSUOg8pPHuauQ3ak9e){:target='_blank'}.
-

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -48,7 +48,7 @@ Many partners choose to create a separate staging app in our sandbox environment
 
 If you are testing an IAL2 integration, then we also offer an ATO-ed staging environment for limited testing. You must have a signed IAA in order to deploy to Staging. Our staging environment is approved for PII, which can be useful in certain test cases. However, any configuration changes in the staging environment must be reviewed and deployed.
 
-If you wish to deploy an application to our Staging environment, then create a “Staging” configuration app like the “Production” configuration app described in the next section.
+If you wish to deploy an application to our staging environment, then create a “staging” configuration app like the “production” configuration app described in the next section.
 
 ## Production configuration
 

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -57,7 +57,7 @@ Before you can deploy your application to the production environment, you will n
 2. Enter a Friendly Name with "Production" in the title
 3. Enter the production urls and configuration into the app
 
-PLEASE NOTE: The following items are required to promote your app to production:
+**Please note**: The following items are required to promote your app to production:
 
 * All production urls should have .gov .mil or a dedicated .com address and point to an ATO'd environment.
 * If your app does not have a logo, then you will need to upload one. You can find the [logo guidelines here](https://developers.login.gov/design-guidelines/#agency-logo-guidelines).

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -59,7 +59,7 @@ Before you can deploy your application to the production environment, you will n
 
 **Please note**: The following items are required to promote your app to production:
 
-* All production urls should have .gov .mil or a dedicated .com address and point to an ATO'd environment.
+* All production urls should have .gov .mil or a dedicated .com address and point to an ATO-ed environment.
 * If your app does not have a logo, then you will need to upload one. You can find the [logo guidelines here](https://developers.login.gov/design-guidelines/#agency-logo-guidelines).
 * If this is an SAML integration (Not OpenID Connect), then please ensure that:
   * Assertion Consumer Logout Service URL is defined.

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -38,7 +38,7 @@ All changes to integrations between login.gov and your application must be revie
 
 ## Confirm IAA
 
-You must have a signed IAA (Inter Agency Agreement) in order to deploy to production. You will need to provide the IAA Number this application will be billed under. The IAA number format will include GTC-Order-ModNumber (Example: LGABCFY210001-0001-0000).
+You must have a signed IAA (Inter Agency Agreement) in order to deploy to production. You will need to provide the IAA Number this application will be billed under. The IAA number format will include `GTC-Order-ModNumber` (Example: `LGABCFY210001-0001-0000`).
 
 Please reach out to your agency IAA contact if you have any questions. If your agency does not already have an IAA, then ask your agency contact to reach out to [partners@login.gov](mailto:partners@login.gov) to begin the IAA process which can take up to 6 weeks to complete.
 

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -24,7 +24,7 @@ sidenav:
 
 ## Production endpoints
 
-Our integration documentation includes endpoint urls for our sandbox environment [https://idp.int.identitysandbox.gov/](https://idp.int.identitysandbox.gov/). Our production environment is located at [https://secure.login.gov/](https://secure.login.gov/). The URL path to each endpoint remains the same. Only the domain will change. For example, the authorization endpoint will change as follows:
+Our integration documentation includes endpoint urls for our sandbox environment <https://idp.int.identitysandbox.gov/>. Our production environment is located at <https://secure.login.gov/>. The URL path to each endpoint remains the same. Only the domain will change. For example, the authorization endpoint will change as follows:
 * OpenID Connect: <https://secure.login.gov/openid_connect/authorize>
 * SAML: <https://secure.login.gov/api/saml/auth2020>
 

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -38,7 +38,7 @@ All changes to integrations between login.gov and your application must be revie
 
 ## Confirm IAA
 
-You must have a signed IAA (Inter Agency Agreement) in order to deploy to production. You will need to provide the IAA Number this application will be billed under. The IAA number format will include `GTC-Order-ModNumber` (Example: `LGABCFY210001-0001-0000`).
+You must have a signed IAA (Inter Agency Agreement) in order to deploy to production. You will need to provide the IAA Number this application will be billed under. The IAA number format will include `GTC-Order-Mod` (e.g. `LGABCFY210001-0001-0000`), where GTC stands for General Terms & Conditions. You may also hear these referred to as forms 7600A and 7600B.
 
 Please reach out to your agency IAA contact if you have any questions. If your agency does not already have an IAA, then ask your agency contact to reach out to [partners@login.gov](mailto:partners@login.gov) to begin the IAA process which can take up to 6 weeks to complete.
 

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -40,7 +40,7 @@ All changes to integrations between login.gov and your application must be revie
 
 You must have a signed IAA (Inter Agency Agreement) in order to deploy to production. You will need to provide the IAA Number this application will be billed under. The IAA number format will include `GTC-Order-Mod` (e.g. `LGABCFY210001-0001-0000`), where GTC stands for General Terms & Conditions. You may also hear these referred to as forms 7600A and 7600B.
 
-Please reach out to your agency IAA contact if you have any questions. If your agency does not already have an IAA, then ask your agency contact to reach out to [partners@login.gov](mailto:partners@login.gov) to begin the IAA process which can take up to 6 weeks to complete.
+Please reach out to your agency IAA contact if you have any questions. If your agency does not already have an IAA, then ask your agency contact to reach out to [partners@login.gov](mailto:partners@login.gov) to begin the IAA process, which can take up to 6 weeks to complete.
 
 ## Staging environment
 

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -28,7 +28,7 @@ Our integration documentation includes endpoint urls for our sandbox environment
 * OpenID Connect: <https://secure.login.gov/openid_connect/authorize>
 * SAML: <https://secure.login.gov/api/saml/auth2020>
 
-Please be aware that the IDP certificate (X509Certificate) in the Production environment is different from the IDP certificate in the sandbox environment. The Production IDP certificates can be found here:
+Please be aware that the IDP certificate (X509 Certificate) in the production environment is different from the IDP certificate in the sandbox environment. The production IDP certificates can be found here:
 * OpenID Connect: <https://secure.login.gov/api/openid_connect/certs>
 * SAML: <https://secure.login.gov/api/saml/metadata2020>
 

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -74,6 +74,6 @@ Once you have:
 
 Please submit the [login.gov production integration request form](https://share.hsforms.com/1UTxHGOu2Q0SVyz9ulknZGw3ak9e){:target='_blank'}.
 
-## Deploying changes
+## Changes to production applications
 
 Please update your production configuration app in the dashboard and test the changes you wish to deploy. After you have confirmed the change, then send a message to [partners@login.gov](mailto:partners@login.gov) requesting a production deployment. Please include a brief description of the change and the url to your production configuration app in the dashboard.

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -46,7 +46,7 @@ Please reach out to your agency IAA contact if you have any questions. If your a
 
 Many partners choose to create a separate staging app in our sandbox environment for testing their staging environment, because changes take effect immediately without waiting for review and deployment.
 
-If you are testing an IAL2 integration, then we also offer a Staging environment for limited testing. You must have a signed IAA in order to deploy to Staging. Our Staging environment is approved for PII which can be useful in certain test cases. However, any configuration changes in the Staging environment must be reviewed and deployed.
+If you are testing an IAL2 integration, then we also offer an ATO-ed staging environment for limited testing. You must have a signed IAA in order to deploy to Staging. Our staging environment is approved for PII, which can be useful in certain test cases. However, any configuration changes in the staging environment must be reviewed and deployed.
 
 If you wish to deploy an application to our Staging environment, then create a “Staging” configuration app like the “Production” configuration app described in the next section.
 

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -25,12 +25,12 @@ sidenav:
 ## Production endpoints
 
 Our integration documentation includes endpoint urls for our sandbox environment https://idp.int.identitysandbox.gov/. Our production environment is located at https://secure.login.gov/. The URL path to each endpoint remains the same. Only the domain will change. For example, the authorization endpoint will change as follows:
-* OpenID Connect - [https://secure.login.gov/openid_connect/authorize](https://secure.login.gov/openid_connect/authorize)
-* SAML - [https://secure.login.gov/api/saml/auth2020](https://secure.login.gov/api/saml/auth2020)
+* OpenID Connect: <https://secure.login.gov/openid_connect/authorize>
+* SAML: <https://secure.login.gov/api/saml/auth2020>
 
 Please be aware that the IDP certificate (X509Certificate) in the Production environment is different from the IDP certificate in the sandbox environment. The Production IDP certificates can be found here:
-* OpenID Connect - [https://secure.login.gov/api/openid_connect/certs](https://secure.login.gov/api/openid_connect/certs)
-* SAML - [https://secure.login.gov/api/saml/metadata2020](https://secure.login.gov/api/saml/metadata2020)
+* OpenID Connect: <https://secure.login.gov/api/openid_connect/certs>
+* SAML: <https://secure.login.gov/api/saml/metadata2020>
 
 ## Deployments
 

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -17,8 +17,8 @@ sidenav:
     href: "#production-configuration"
   - text: Request deployment
     href: "#request-deployment"
-  - text: Deploying changes
-    href: "#deploying-changes"
+  - text: Changes to production applications
+    href: "#production-changes"
 ---
 
 
@@ -76,4 +76,5 @@ Please submit the [login.gov production integration request form](https://share.
 
 ## Changes to production applications
 
-Please update your production configuration app in the dashboard and test the changes you wish to deploy. After you have confirmed the change, then send a message to [partners@login.gov](mailto:partners@login.gov) requesting a production deployment. Please include a brief description of the change and the url to your production configuration app in the dashboard.
+Please update your production configuration app in the dashboard and test the changes you wish to deploy. After you have confirmed the change, then please submit the [login.gov integration change request form](https://share.hsforms.com/1HF9Q6UNARaSUOg8pPHuauQ3ak9e){:target='_blank'}.
+

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -24,7 +24,7 @@ sidenav:
 
 ## Production endpoints
 
-Our integration documentation includes endpoint urls for our sandbox environment https://idp.int.identitysandbox.gov/. Our production environment is located at https://secure.login.gov/. The URL path to each endpoint remains the same. Only the domain will change. For example, the authorization endpoint will change as follows:
+Our integration documentation includes endpoint urls for our sandbox environment [https://idp.int.identitysandbox.gov/](https://idp.int.identitysandbox.gov/). Our production environment is located at [https://secure.login.gov/](https://secure.login.gov/). The URL path to each endpoint remains the same. Only the domain will change. For example, the authorization endpoint will change as follows:
 * OpenID Connect: <https://secure.login.gov/openid_connect/authorize>
 * SAML: <https://secure.login.gov/api/saml/auth2020>
 

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -60,7 +60,7 @@ Before you can deploy your application to the production environment, you will n
 **Please note**: The following items are required to promote your app to production:
 
 * All production urls should have .gov .mil or a dedicated .com address and point to an ATO-ed environment.
-* If your app does not have a logo, then you will need to upload one. You can find the [logo guidelines here](https://developers.login.gov/design-guidelines/#agency-logo-guidelines).
+* You must include a logo for your application. You can find the [logo guidelines here](https://developers.login.gov/design-guidelines/#agency-logo-guidelines).
 * If this is an SAML integration (Not OpenID Connect), then please ensure that:
   * Assertion Consumer Logout Service URL is defined.
   * SAML Assertion Encryption is enabled.

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -61,7 +61,7 @@ Before you can deploy your application to the production environment, you will n
 
 * All production urls should have .gov .mil or a dedicated .com address and point to an ATO-ed environment.
 * You must include a logo for your application. You can find the [logo guidelines here](https://developers.login.gov/design-guidelines/#agency-logo-guidelines).
-* If this is an SAML integration (Not OpenID Connect), then please ensure that:
+* If this is a SAML integration (Not OpenID Connect), then please ensure that:
   * Assertion Consumer Logout Service URL is defined.
   * SAML Assertion Encryption is enabled.
     * If you are using a service which does not support SAML encryption, then please send a message to [partners@login.gov](mailto:partners@login.gov) for further guidance.

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -34,7 +34,7 @@ Please be aware that the IDP certificate (X509 Certificate) in the production en
 
 ## Deployments
 
-All changes to integrations between login.gov and your application must be reviewed and deployed. We ask for 1 week notice for new integrations and changes to existing integrations. Regular deployments occur every Thursday by the close of business day. If the regular deployment occurs on a holiday, then it will be completed the following Monday.
+All changes to integrations between login.gov and your application must be reviewed and deployed. We ask for at least 1 week notice for new integrations and changes to existing integrations. Regular deployments occur every Thursday by the close of the business day. If the regular deployment occurs on a holiday, then it will be completed the following Monday.
 
 ## Confirm IAA
 


### PR DESCRIPTION
WHY:
Adding article that describes the process to deploy a new app to production. Also introduces the production deploy form.