### PR TITLE
add ial and aal to attributes

### DIFF
--- a/_pages/attributes.md
+++ b/_pages/attributes.md
@@ -55,6 +55,48 @@ Requires the `email` scope.
     </tr>
     <tr>
 <td markdown="1">
+**IAL**<br />Identity Assurance Level [NIST 800-63-3](https://pages.nist.gov/800-63-3/).
+</td>
+<td markdown="1">
+![checkmark][checkmark]
+</td>
+<td markdown="1">
+![checkmark][checkmark]
+</td>
+<td markdown="1">
+`ial` (url, urn)
+
+See [OpenID Connect IAL values](https://developers.login.gov/oidc/#ial-values)
+</td>
+<td markdown="1">
+`ial` (url, urn)
+
+See [SAML IAL values](https://developers.login.gov/saml/#identity-assurance-level-ial)
+</td>
+    </tr>
+    <tr>
+<td markdown="1">
+**AAL**<br />Authenticator Assurance Level [NIST 800-63-3](https://pages.nist.gov/800-63-3/).
+</td>
+<td markdown="1">
+![checkmark][checkmark]
+</td>
+<td markdown="1">
+![checkmark][checkmark]
+</td>
+<td markdown="1">
+`aal` (url, urn)
+
+See [OpenID Connect AAL values](https://developers.login.gov/oidc/#aal-values)
+</td>
+<td markdown="1">
+`aal` (url, urn)
+
+See [SAML AAL values](https://developers.login.gov/saml/#authentication-assurance-level-aal)
+</td>
+    </tr>
+    <tr>
+<td markdown="1">
 **First name**<br />The user's first (given) name.
 </td>
 <td></td>

--- a/_pages/oidc.md
+++ b/_pages/oidc.md
@@ -110,7 +110,12 @@ https://idp.int.identitysandbox.gov/openid_connect/authorize?
 
 
   #### AAL Values
-  We default to requiring a user to be authenticated with a second factor. Stricter behavior can be specified by adding one of:
+  We default to requiring a user to be authenticated with a second factor:
+
+  - **`urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo`**
+      This specifies that a user has been authenticated with a second factor. This value will be returned in the user attributes by default. We do not allow AAL 1, because it implies that a user did not authenticate with a second factor.
+
+  Stricter behavior can be specified by adding one of:
 
     - **`http://idmanagement.gov/ns/assurance/aal/3`**
         This specifies that a user has been authenticated with a crytographically secure method, such as WebAuthn or using a PIV/CAC.

--- a/_pages/saml.md
+++ b/_pages/saml.md
@@ -265,7 +265,12 @@ To specify one of the supported IAL levels, place one of these values inside a `
 
 #### Authentication Assurance Level (AAL)
 
-We default to requiring a user to be authenticated with a second factor. To specify a stricter AAL level, add an additional `<saml:AuthnContextClassRef>` with one of these values:
+We default to requiring a user to be authenticated with a second factor.
+
+- **`urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo`**
+    This specifies that a user has been authenticated with a second factor. This value will be returned in the user attributes by default. We do not allow AAL 1, because it implies that a user did not authenticate with a second factor.
+
+To specify a stricter AAL level, add an additional `<saml:AuthnContextClassRef>` with one of these values:
 
   - **`http://idmanagement.gov/ns/assurance/aal/3`**
       This specifies that a user has been authenticated with a crytographically secure method, such as WebAuthn or using a PIV/CAC.

--- a/_pages/saml.md
+++ b/_pages/saml.md
@@ -265,7 +265,7 @@ To specify one of the supported IAL levels, place one of these values inside a `
 
 #### Authentication Assurance Level (AAL)
 
-We default to requiring a user to be authenticated with a second factor.
+We default to requiring a user to be authenticated with a second factor:
 
 - **`urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo`**
     This specifies that a user has been authenticated with a second factor. This value will be returned in the user attributes by default. We do not allow AAL 1, because it implies that a user did not authenticate with a second factor.


### PR DESCRIPTION
WHY:
Adding IAL and AAL values to the attributes page. I am also adding the new default AAL value to SAML and OIDC.