### PR TITLE
Turn RISC events into a data file, export data/risc.json

### DIFF
--- a/_data/risc.yml
+++ b/_data/risc.yml
@@ -1,0 +1,70 @@
+- friendly_name: Authorization Fraud Detected
+  direction: incoming
+  event_type: https://schemas.login.gov/secevent/risc/event-type/authorization-fraud-detected
+  description: >
+    RPs should submit this event when they believe a user's credentials have been compromised,
+    that somebody who is not the user was able to sign in to a user's account. Login.gov may force
+    the reset of user's password when we receive this event.
+- friendly_name: Identity Fraud Detected
+  direction: incoming
+  event_type: https://schemas.login.gov/secevent/risc/event-type/identity-fraud-detected
+  description: >
+    RPs should submit this event when they suspect an account has been used to commit identity theft or related fraudulent activity. Login.gov may reset the user's profile and verified attributes data when we receive this event.
+
+- friendly_name: Account Purged
+  direction: outgoing
+  event_type: https://schemas.openid.net/secevent/risc/event-type/account-purged
+  description: >
+    Login.gov pushes this event when a user deletes their account.
+  payload_schema:
+    - key: subject
+      description: An event should will a **subject** object, with the following keys
+      properties:
+        - key: subject_type
+          type: string
+          description: >
+            Will be **iss-sub**, this indicates the **sub** is the subject provided by the original issuer (login.gov)
+        - key: iss
+          type: string
+          description: >
+            This is login.gov's issuer, the root URL for login.gov. In the agency integration environment, this is `https://idp.int.identitysandbox.gov`
+        - key: sub
+          type: string
+          description: >
+            The UUID identifying the user. This is the same as the  `sub` inside the `id_token` JWT in the  [OpenID Token endpoint]({{site.baseurl}}/#token-response).
+  example_payload: {
+    "https://schemas.openid.net/secevent/risc/event-type/account-purged": {
+      "subject": {
+        "subject_type": "iss-sub",
+        "iss": "https://idp.int.identitysandbox.gov",
+        "sub": "<$SUB>"
+      }
+    }
+  }
+
+- friendly_name: Identifier Recycled
+  direction: outgoing
+  event_type: https://schemas.openid.net/secevent/risc/event-type/identifier-recycled
+  description: >
+    Login.gov pushes this event when a user removes an email address from their account, freeing up the email address as an identifier.
+  payload_schema:
+    - key: subject
+      description: An event should will a **subject** object, with the following keys
+      properties:
+        - key: subject_type
+          type: string
+          description: >
+            Will be **email**
+        - key: email
+          type: string
+          description: >
+            This is the email address that no longer belongs to any user.
+  example_payload: {
+    "https://schemas.openid.net/secevent/risc/event-type/identifier-recycled": {
+      "subject": {
+        "subject_type": "email",
+        "email": "<$EMAIL>"
+      }
+    }
+  }
+

--- a/_data/risc.yml
+++ b/_data/risc.yml
@@ -1,3 +1,6 @@
+#
+# Incoming Events
+#
 - friendly_name: Authorization Fraud Detected
   direction: incoming
   event_type: https://schemas.login.gov/secevent/risc/event-type/authorization-fraud-detected
@@ -5,12 +8,16 @@
     RPs should submit this event when they believe a user's credentials have been compromised,
     that somebody who is not the user was able to sign in to a user's account. Login.gov may force
     the reset of user's password when we receive this event.
+
 - friendly_name: Identity Fraud Detected
   direction: incoming
   event_type: https://schemas.login.gov/secevent/risc/event-type/identity-fraud-detected
   description: >
     RPs should submit this event when they suspect an account has been used to commit identity theft or related fraudulent activity. Login.gov may reset the user's profile and verified attributes data when we receive this event.
 
+#
+# Outgoing Events
+#
 - friendly_name: Account Purged
   direction: outgoing
   event_type: https://schemas.openid.net/secevent/risc/event-type/account-purged

--- a/_data/risc_incoming.yml
+++ b/_data/risc_incoming.yml
@@ -1,0 +1,17 @@
+#
+# Incoming Events
+#
+- friendly_name: Authorization Fraud Detected
+  direction: incoming
+  event_type: https://schemas.login.gov/secevent/risc/event-type/authorization-fraud-detected
+  description: >
+    RPs should submit this event when they believe a user's credentials have been compromised,
+    that somebody who is not the user was able to sign in to a user's account. Login.gov may force
+    the reset of user's password when we receive this event.
+
+- friendly_name: Identity Fraud Detected
+  direction: incoming
+  event_type: https://schemas.login.gov/secevent/risc/event-type/identity-fraud-detected
+  description: >
+    RPs should submit this event when they suspect an account has been used to commit identity theft or related fraudulent activity. Login.gov may reset the user's profile and verified attributes data when we receive this event.
+

--- a/_data/risc_outgoing.yml
+++ b/_data/risc_outgoing.yml
@@ -1,21 +1,4 @@
 #
-# Incoming Events
-#
-- friendly_name: Authorization Fraud Detected
-  direction: incoming
-  event_type: https://schemas.login.gov/secevent/risc/event-type/authorization-fraud-detected
-  description: >
-    RPs should submit this event when they believe a user's credentials have been compromised,
-    that somebody who is not the user was able to sign in to a user's account. Login.gov may force
-    the reset of user's password when we receive this event.
-
-- friendly_name: Identity Fraud Detected
-  direction: incoming
-  event_type: https://schemas.login.gov/secevent/risc/event-type/identity-fraud-detected
-  description: >
-    RPs should submit this event when they suspect an account has been used to commit identity theft or related fraudulent activity. Login.gov may reset the user's profile and verified attributes data when we receive this event.
-
-#
 # Outgoing Events
 #
 - friendly_name: Account Purged

--- a/_includes/risc_event.json
+++ b/_includes/risc_event.json
@@ -1,0 +1,11 @@
+{% comment %}
+Include:
+- event
+- direction (incoming/outgoing)
+{% endcomment %}
+{
+  "friendly_name": {{ include.event.friendly_name | jsonify }},
+  "event_type": {{ include.event.event_type | jsonify}},
+  "direction": {{ include.direction | jsonify }},
+  "description": {{ include.event.description | strip | jsonify }}
+}

--- a/_includes/schema.html
+++ b/_includes/schema.html
@@ -1,0 +1,25 @@
+{% comment %}
+Includes:
+- schema, array of:
+    - key
+    - description
+    - type (optional)
+    - properties (optional)
+{% endcomment %}
+<ul>
+  {% for item in include.schema %}
+    <li>
+<div markdown="1">
+**{{ item.key }}**
+{%- if item.type -%}
+  ({{ item.type }})
+{%- endif -%}
+<br />
+{{ item.description }}
+</div>
+      {% if item.properties %}
+        {% include schema.html schema=item.properties %}
+      {% endif %}
+    </li>
+  {% endfor %}
+</ul>

--- a/_pages/risc.json
+++ b/_pages/risc.json
@@ -5,13 +5,12 @@ layout: none
 {%- capture json -%}
 {
   "supported_events": [
-    {% for event in site.data.risc %}
-      {
-        "friendly_name": {{ event.friendly_name | jsonify }},
-        "event_type": {{ event.event_type | jsonify}},
-        "direction": {{ event.direction | jsonify }},
-        "description": {{ event.description | strip | jsonify }}
-      }
+    {% for event in site.data.risc_incoming %}
+      {% include risc_event.json event=event direction="incoming" %}
+      ,
+    {% endfor %}
+    {% for event in site.data.risc_outgoing %}
+      {% include risc_event.json event=event direction="outgoing" %}
       {% unless forloop.last %},{% endunless %}
     {% endfor %}
   ]

--- a/_pages/risc.json
+++ b/_pages/risc.json
@@ -1,0 +1,20 @@
+---
+permalink: /data/risc.json
+layout: none
+---
+{%- capture json -%}
+{
+  "supported_events": [
+    {% for event in site.data.risc %}
+      {
+        "friendly_name": {{ event.friendly_name | jsonify }},
+        "event_type": {{ event.event_type | jsonify}},
+        "direction": {{ event.direction | jsonify }},
+        "description": {{ event.description | strip | jsonify }}
+      }
+      {% unless forloop.last %},{% endunless %}
+    {% endfor %}
+  ]
+}
+{%- endcapture -%}
+{{ json | pretty_jsonify }}

--- a/_pages/security-events.md
+++ b/_pages/security-events.md
@@ -259,7 +259,7 @@ Example:
 
 ### Request
 
-login.gov will make a POST request to your app's `push_notification_url`, see [Configuration](#configuration) for more details on setting that up. The JWT will be signed with login.gov's private key. See the OpenID Connect guide for information on how to get login.gov's public key from the [Certificates Endpoint](/oidc/#certificates).
+Login.gov will make a POST request to your app's `push_notification_url`, see [Configuration](#configuration) for more details on setting that up. The JWT will be signed with login.gov's private key. See the OpenID Connect guide for information on how to get login.gov's public key from the [Certificates Endpoint](/oidc/#certificates).
 
 If your app had the client ID of `urn:gov:gsa:openidconnect:test:risc:sets` and was configured to receive events at `https://agency.example.gov/events`, and a user freed up `email@example.com` login.gov would make a like this.
 

--- a/_pages/security-events.md
+++ b/_pages/security-events.md
@@ -49,30 +49,25 @@ Login.gov provides a JSON endpoint for OpenID Connect auto-discovery at `/.well-
 
 Login.gov accepts custom events, based on the [OpenID RISC Event Types][openid-risc-events], but not specific ones from that list at this time.
 
-- [Authorization Fraud Detected](#authorization-fraud-detected)
-- [Identity Fraud Detected](#identity-fraud-detected)
+{% assign incoming_events = site.data.risc | where: 'direction', 'incoming' %}
 
-#### Authorization Fraud Detected
+{%- for event in incoming_events %}
+- [{{ event.friendly_name }}](#{{ event.friendly_name | slugify }})
+{%- endfor %}
 
-RPs should submit this event when they believe a user's credentials have been compromised, that somebody who is not the user
-was able to sign in to a user's account. Login.gov may force the reset of user's password when we receive this event.
+{% for event in incoming_events %}
 
-The **event_type** for this is:
+#### {{ event.friendly_name }}
 
-```
-https://schemas.login.gov/secevent/risc/event-type/authorization-fraud-detected
-```
-
-#### Identity Fraud Detected
-
-RPs should submit this event when they suspect an account has been used to commit identity theft or related fraudulent activity. Login.gov may reset the user's profile and verified attributes data when we receive this event.
+{{ event.description | markdownify }}
 
 The **event_type** for this is:
 
 ```
-https://schemas.login.gov/secevent/risc/event-type/identity-fraud-detected
+{{ event.event_type }}
 ```
 
+{% endfor %}
 
 ### Request
 
@@ -232,78 +227,35 @@ To configure your application to receive notifications from login.gov, supply lo
 
 Login.gov notifies for these events from the [OpenID RISC Event Types][openid-risc-events]:
 
-- [Account Purged](#account-purged)
-- [Identifier Recycled](#identifier-recycled)
+{% assign outgoing_events = site.data.risc | where: 'direction', 'outgoing' %}
 
-#### Account Purged
+{%- for event in outgoing_events %}
+- [{{ event.friendly_name }}](#{{ event.friendly_name | slugify }})
+{%- endfor %}
 
-Login.gov pushes this event when a user deletes their account.
+{% for event in outgoing_events %}
+
+#### {{ event.friendly_name }}
+
+{{ event.description | markdownify }}
 
 The **event_type** for this is:
+
 ```
-https://schemas.openid.net/secevent/risc/event-type/account-purged
+{{ event.event_type }}
 ```
 
-The event payload has
+The event payload has:
 
-* **subject**
-    An event should will a **subject** object, with the following keys:
-
-    * **subject_type** (string)
-      Will be **iss-sub**, this indicates the **sub** is the subject provided by the original issuer (login.gov)
-
-    * **iss** (string)
-      This is login.gov's issuer, the root URL for login.gov. In the agency integration environment, this is `https://idp.int.identitysandbox.gov`
-
-    * **sub** (string)
-      The UUID identifying the user. This is the same as the  `sub` inside the `id_token` JWT in the [OpenID Token endpoint]({{site.baseurl}}/#token-response).
+{% include schema.html schema=event.payload_schema %}
 
 Example:
 
 ```json
-{
-  "https://schemas.openid.net/secevent/risc/event-type/account-purged": {
-    "subject": {
-      "subject_type": "iss-sub",
-      "iss": "https://idp.int.identitysandbox.gov",
-      "sub": "<$SUB>"
-    }
-  }
-}
+{{ event.example_payload | jsonify | pretty_jsonify }}
 ```
 
-#### Identifier Recycled
-
-Login.gov pushes this event when a user removes an email address from their account, freeing up the email address as an identifier.
-
-The **event_type** for this is:
-```
-https://schemas.openid.net/secevent/risc/event-type/identifier-recycled
-```
-
-The event payload has
-
-* **subject**
-    An event should will a **subject** object, with the following keys:
-
-    * **subject_type** (string)
-      This will be **email**
-
-    * **email** (string)
-      This is the email address that no longer belongs to any user.
-
-Example:
-
-```json
-{
-  "https://schemas.openid.net/secevent/risc/event-type/identifier-recycled": {
-    "subject": {
-      "subject_type": "email",
-      "email": "<$EMAIL>"
-    }
-  }
-}
-```
+{% endfor %}
 
 ### Request
 

--- a/_pages/security-events.md
+++ b/_pages/security-events.md
@@ -49,13 +49,11 @@ Login.gov provides a JSON endpoint for OpenID Connect auto-discovery at `/.well-
 
 Login.gov accepts custom events, based on the [OpenID RISC Event Types][openid-risc-events], but not specific ones from that list at this time.
 
-{% assign incoming_events = site.data.risc | where: 'direction', 'incoming' %}
-
-{%- for event in incoming_events %}
+{%- for event in site.data.risc_incoming %}
 - [{{ event.friendly_name }}](#{{ event.friendly_name | slugify }})
 {%- endfor %}
 
-{% for event in incoming_events %}
+{% for event in site.data.risc_incoming %}
 
 #### {{ event.friendly_name }}
 
@@ -227,13 +225,11 @@ To configure your application to receive notifications from login.gov, supply lo
 
 Login.gov notifies for these events from the [OpenID RISC Event Types][openid-risc-events]:
 
-{% assign outgoing_events = site.data.risc | where: 'direction', 'outgoing' %}
-
-{%- for event in outgoing_events %}
+{%- for event in site.data.risc_outgoing %}
 - [{{ event.friendly_name }}](#{{ event.friendly_name | slugify }})
 {%- endfor %}
 
-{% for event in outgoing_events %}
+{% for event in site.data.risc_outgoing %}
 
 #### {{ event.friendly_name }}
 

--- a/_plugins/pretty_jsonify.rb
+++ b/_plugins/pretty_jsonify.rb
@@ -1,0 +1,17 @@
+require 'json'
+
+module LoginGov
+  module PrettyJsonify
+    def pretty_jsonify(input)
+      json = if input.kind_of?(String)
+        JSON.parse(input)
+      else
+        json
+      end
+
+      JSON.pretty_generate(json)
+    end
+  end
+end
+
+Liquid::Template.register_filter(LoginGov::PrettyJsonify)

--- a/spec/risc.json_spec.rb
+++ b/spec/risc.json_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require 'json'
+
+RSpec.describe '_site/data/risc.json' do
+  let(:json) { JSON.parse(File.read('_site/data/risc.json')) }
+
+  it 'is is an array of supported_events' do
+    expect(json).to be
+    expect(json['supported_events']).to be_a(Array)
+  end
+end


### PR DESCRIPTION
A discussion with @juliaelman on RISC events in the dashboard turned into "wouldn't it be nice to show the pretty name of an event in the dashboard?"

So then I figured we could expose the data from the dev docs as a `.json` that the dashboard could load + cache

I also realized that now that we're adding a few more types of RISC events, so hopefully this could help us document there

Future ideas:
- Maybe instead of one long `/security` page, we break each event into its own page and deep link there?
- A field to link to the OpenID spec for particular RISC events