### PR TITLE
Add int maintenance alert to all pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [View it live ❯](https://developers.login.gov/)
 
+## Temporary Alert
+
+To add a temporary alert to the developer docs set the `temporary_alert` configuration value in `_config.yml` to a string with the desired alert contents, e.g. `The sandbox will be unavailable from <b>5:30-6:30p ET on Tuesday, August 9th</b>.`. To turn off the alert change the configuration value to `false`.
+
 ## Development
 
 ### Docker

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,9 @@ title: Login.gov
 description: Welcome to the Login.gov developer documentation!
 github_repo_url: https://github.com/18F/identity-dev-docs # enables "edit this page" button
 
+temporary_alert: "The Login.gov sandbox (<b>not production</b>) will be unavailable from <b>5:30-6:30p ET on Tuesday, August 9th</b> for maintenance."
+# temporary_alert: false
+
 plugins:
   - jekyll-redirect-from
 

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -19,6 +19,11 @@ layout: base
         </aside>
 
         <div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">
+
+          {% if site.temporary_alert %}
+            {% include alert.html content=site.temporary_alert %}
+          {% endif %}
+
           <div class="usa-display">{{ page.title }}</div>
 
           {% if page.lead %}
@@ -30,6 +35,11 @@ layout: base
       </div>
     {% else %}
       <div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">
+
+        {% if site.temporary_alert %}
+          {% include alert.html content=site.temporary_alert %}
+        {% endif %}
+
         <div class="usa-display">{{ page.title }}</div>
 
         {% if page.lead %}

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -14,6 +14,11 @@ layout: home
 </section>
 
 <section class="usa-section grid-container usa-prose" markdown="1">
+
+  {% if site.temporary_alert %}
+    {% include alert.html content=site.temporary_alert %}
+  {% endif %}
+
 # Get started...
 
 - [Understand our flow]({{ site.baseurl }}/overview/).


### PR DESCRIPTION
This can be turned on by specifying the timeframe in _config.yml and
turned off by setting the `int_maintenance_window` configuration value
to `false`.