### PR TITLE
Updating a field comment that was copy-pasted across two events

### DIFF
--- a/_data/risc_outgoing.yml
+++ b/_data/risc_outgoing.yml
@@ -39,7 +39,7 @@
   spec_url: "https://openid.net/specs/openid-risc-event-types-1_0-ID1.html#rfc.section.2.6"
   description: >
     Login.gov pushes this event when a user removes an email address from their account, freeing up the email address as an identifier.
-  payload_schema: &email_schema
+  payload_schema:
     - key: subject
       description: An event should will a **subject** object, with the following keys
       properties:
@@ -67,7 +67,17 @@
   description: >
     Login.gov pushes this event when a user changes the email address on their account.
   payload_schema:
-    *email_schema
+    - key: subject
+      description: An event should will a **subject** object, with the following keys
+      properties:
+        - key: subject_type
+          type: string
+          description: >
+            Will be **email**
+        - key: email
+          type: string
+          description: >
+            The new email address that was added, or the the email address that was removed.
   example_payload: {
     "https://schemas.openid.net/secevent/risc/event-type/identifier-changed": {
       "subject": {


### PR DESCRIPTION
| | identifier-changed | identifier-recycled |
|---|----|---|
| email added | ✅ |  |
| email deleted | ✅* | ✅ |

So [looking at the code](https://github.com/18F/identity-idp/blob/1c6d88911e15edcf5ae92443c325324a00611018/app/forms/delete_user_email_form.rb#L28-L33) we send "identifier-changed" when an email is added and deleted? but i think it would make sense if we only did one? This standard is tough lol
