### PR TITLE
Add the state_id_number and state_id_type to the sample YAML

### DIFF
--- a/assets/yaml/proofing.yml
+++ b/assets/yaml/proofing.yml
@@ -10,4 +10,6 @@ document:
   zipcode: '11364'
   dob: 10/06/1938
   phone: +1 314-555-1212
+  state_id_number: '123456789'
+  state_id_type: drivers_license
   state_id_jurisdiction: 'NY'


### PR DESCRIPTION
These values are used by the state ID mock proofer. This commit adds them both for visibility and to prevent their absence from causing problems (e.g. https://github.com/18F/identity-idp/pull/7205)