### PR TITLE
Remove banner, corresponding update content was removed in #271

### DIFF
--- a/_pages/oidc.md
+++ b/_pages/oidc.md
@@ -34,8 +34,6 @@ sidenav:
 
 ---
 
-{% include alert.html content="Please see important information <a href='#logout'>below</a> about upcoming changes to the logout endpoint" alert_class="usa-alert--warning" %}
-
 ## Getting started
 
 ### Choosing an authentication method


### PR DESCRIPTION
small follow up to #271. this banner is still up but the corresponding update info has been removed


<img width="814" alt="Screen Shot 2023-01-24 at 1 12 59 PM" src="https://user-images.githubusercontent.com/458784/214417412-41fa9cde-04e8-42d4-b676-12a358a46adf.png">
