### PR TITLE
Fix bottom banner text color

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -9,3 +9,12 @@
 #nav-links {
     width: fit-content !important;
 }
+
+//override for touchpoints survey included via script 
+#fba-modal-dialog .usa-banner__header-text {
+    color: white;
+
+    a {
+        color: white;
+    }
+}


### PR DESCRIPTION
After adding the survey to production, Annie noticed that the bottom banner had the wrong text color. This is a quick CSS fix to change the color. (see screenshots below) 

<img width="599" alt="Screen Shot 2023-02-22 at 10 18 39 AM" src="https://user-images.githubusercontent.com/6639858/220720634-2d7faf91-d8b0-48ce-841b-d37920203d84.png">
<img width="578" alt="Screen Shot 2023-02-22 at 10 18 27 AM" src="https://user-images.githubusercontent.com/6639858/220720645-a93f2eb9-1bed-4813-bd85-d5287ab4d408.png">
