### PR TITLE
Add markdown parsing for lead section

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -43,7 +43,7 @@ layout: base
         <div class="usa-display">{{ page.title }}</div>
 
         {% if page.lead %}
-          <p class="usa-intro">{{ page.lead | markdownify }}</p>
+          <div class="usa-intro">{{ page.lead | markdownify }}</div>
         {% endif %}
 
         {{ content }}


### PR DESCRIPTION
Links and other markdown are currently not parsed in this section. Thanks @aduth for suggesting this fix!