### PR TITLE
Add Jekyll plugin to apply design system styling to links

### DIFF
--- a/_plugins/content_typography.rb
+++ b/_plugins/content_typography.rb
@@ -1,0 +1,12 @@
+module Kramdown
+  module Parser
+    class Kramdown
+      prepend(Module.new do
+        def add_link(el, *args)
+          el.attr['class'] = [*el.attr['class'], 'usa-link'].join(' ') if el.type == :a
+          super(el, *args)
+        end
+      end)
+    end
+  end
+end


### PR DESCRIPTION
Why: For consistent user experience across Login.gov properties.

This plugin is used already across a few Login.gov sites:

- [`18f/identity-style-guide`](https://github.com/18F/identity-style-guide/blob/main/docs/_plugins/content_typography.rb)
- [`18f/identity-handbook`](https://github.com/18F/identity-handbook/blob/main/_plugins/content_typography.rb)

Before|After
---|---
![developers login gov_](https://user-images.githubusercontent.com/1779930/227217270-a72d9272-4362-4959-a30b-95e368d65c2d.png)|![localhost_54902_](https://user-images.githubusercontent.com/1779930/227217284-d9fbfd83-5192-4ef4-bc87-f1b68d627a29.png)
