### PR TITLE
Update to null attributes

### DIFF
--- a/_pages/attributes.md
+++ b/_pages/attributes.md
@@ -175,7 +175,7 @@ Requires the `address` scope.
     </tr>
     <tr>
 <td markdown="1">
-**Phone**<br />The user's phone number formatted as [E.164](https://en.wikipedia.org/wiki/E.164), for example: `+18881112222`
+  **Phone<sup>1</sup>**<br />The user's phone number formatted as [E.164](https://en.wikipedia.org/wiki/E.164), for example: `+18881112222`
 </td>
 <td></td>
 <td markdown="1">
@@ -227,7 +227,7 @@ Requires the `social_security_number` scope.
     </tr>
     <tr>
 <td markdown="1">
-**Verification timestamp** <br />
+  **Verification timestamp<sup>1</sup>** <br />
 When the user's identity was last verified (or empty if it has never been verified)
 </td>
 <td markdown="1">
@@ -327,5 +327,6 @@ Requires the `x509:presented` scope.
     </tr>
   </tbody>
 </table>
+<sup>1</sup> Please note that only `phone` and `verified_at` idV user attributes may be returned as null.
 
 [checkmark]: {{ site.baseurl }}/assets/img/check.svg

--- a/_pages/attributes.md
+++ b/_pages/attributes.md
@@ -175,7 +175,7 @@ Requires the `address` scope.
     </tr>
     <tr>
 <td markdown="1">
-  **Phone<sup>1</sup>**<br />The user's phone number formatted as [E.164](https://en.wikipedia.org/wiki/E.164), for example: `+18881112222`
+  **Phone<sup>*</sup>**<br />The user's phone number formatted as [E.164](https://en.wikipedia.org/wiki/E.164), for example: `+18881112222`
 </td>
 <td></td>
 <td markdown="1">
@@ -227,7 +227,7 @@ Requires the `social_security_number` scope.
     </tr>
     <tr>
 <td markdown="1">
-  **Verification timestamp<sup>1</sup>** <br />
+  **Verification timestamp<sup>*</sup>** <br />
 When the user's identity was last verified (or empty if it has never been verified)
 </td>
 <td markdown="1">
@@ -327,6 +327,6 @@ Requires the `x509:presented` scope.
     </tr>
   </tbody>
 </table>
-<sup>1</sup> Please note that only `phone` and `verified_at` idV user attributes may be returned as null.
+<sup>*</sup> Please note that only `phone` and `verified_at` idV user attributes may be returned as null.
 
 [checkmark]: {{ site.baseurl }}/assets/img/check.svg


### PR DESCRIPTION
Per update to User Attributes (https://docs.google.com/document/d/1NuNpx3F5K8b8Me2Ef8cjPrnzjmD7INSI54CvJ25c-QI/edit?usp=sharing) to note the two attributes that can be returned as null.

(this PR replaces https://github.com/18F/identity-dev-docs/pull/314)
Changed 1 to * 