### PR TITLE
Upgrade Login.gov Design System to v7.0.1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ whitelist:
   - jekyll-redirect-from
 
 copy_to_destination:
-  - node_modules/identity-style-guide/dist/assets
+  - node_modules/@18f/identity-design-system/dist/assets
 
 # Pages
 collections:

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -25,7 +25,6 @@
     <meta property="og:type" content="article">
 
     <link rel="shortcut icon" type="image/ico" href="{{ site.baseurl }}/assets/img/favicons/favicon.ico">
-    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/styles.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css">
   </head>
 
@@ -142,7 +141,7 @@
             <div class="grid-col-auto">
               <h3 class="usa-footer__logo-heading">U.S. General Services Administration</h3>
             </div>
-            <div class="grid-col-auto tablet:grid-col-fill text-right">
+            <div class="grid-col-fill text-right">
               <a href="https://status.login.gov/">System Status</a>
             </div>
           </div>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -90,31 +90,31 @@
     <div class="usa-overlay"></div>
 
     <header class="usa-header usa-header--extended" role="banner">
-      <div class="usa-nav-container">
-        <div class="usa-navbar">
-          <div class="usa-logo" id="basic-logo">
-            <a href="{{ site.baseurl }}/" title="Home" aria-label="Home">
-              <img src="{{ site.baseurl }}/assets/img/login-gov-logo.svg"
-                class="usa-logo__img"
-                alt="Login.gov"
-                role="img">
-              <em class="usa-logo__text">Developers</em>
-            </a>
-          </div>
-          <button class="usa-menu-btn">Menu</button>
+      <div class="usa-navbar">
+        <div class="usa-logo" id="basic-logo">
+          <a href="{{ site.baseurl }}/" title="Home" aria-label="Home">
+            <img src="{{ site.baseurl }}/assets/img/login-gov-logo.svg"
+              class="usa-logo__img"
+              alt="Login.gov"
+              role="img">
+            <em class="usa-logo__text">Developers</em>
+          </a>
         </div>
-        <nav role="navigation" class="usa-nav border-top-none">
+        <button class="usa-menu-btn">Menu</button>
+      </div>
+      <nav role="navigation" class="usa-nav border-top-none">
+        <div class="usa-nav__inner">
           <button class="usa-nav__close">
             <img src="{{ site.baseurl }}/assets/img/close.svg" alt="Close" role="img">
           </button>
-          <ul class="usa-nav__primary usa-accordion" id="nav-links">
+          <ul class="usa-nav__primary usa-accordion">
             {% include nav/list.html
               links = site.data.nav.primary
               li_class = 'usa-nav__primary-item'
             %}
           </ul>
-        </nav>
-      </div>
+        </div>
+      </nav>
     </header>
 
     {{ content }}

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -6,7 +6,7 @@ layout: base
   <div class="grid-container">
     {% if page.sidenav %}
       <div class="grid-row grid-gap">
-        <aside class="usa-layout-docs__sidenav desktop:grid-col-3">
+        <aside class="usa-layout-docs__sidenav tablet:grid-col-3">
           <nav>
             <ul class="usa-sidenav">
               {% include nav/list.html
@@ -18,13 +18,13 @@ layout: base
           </nav>
         </aside>
 
-        <div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">
+        <div class="usa-layout-docs__main tablet:grid-col-9 usa-prose">
 
           {% if site.temporary_alert %}
             {% include alert.html content=site.temporary_alert %}
           {% endif %}
 
-          <div class="usa-display">{{ page.title }}</div>
+          <h1 class="usa-display">{{ page.title }}</h1>
 
           {% if page.lead %}
             <div class="usa-intro">{{ page.lead | markdownify }}</div>
@@ -34,13 +34,13 @@ layout: base
         </div>
       </div>
     {% else %}
-      <div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">
+      <div class="usa-layout-docs__main tablet:grid-col-9 usa-prose">
 
         {% if site.temporary_alert %}
           {% include alert.html content=site.temporary_alert %}
         {% endif %}
 
-        <div class="usa-display">{{ page.title }}</div>
+        <h1 class="usa-display">{{ page.title }}</h1>
 
         {% if page.lead %}
           <div class="usa-intro">{{ page.lead | markdownify }}</div>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -6,7 +6,7 @@ layout: base
   <div class="grid-container">
     {% if page.sidenav %}
       <div class="grid-row grid-gap">
-        <aside class="usa-layout-docs__sidenav tablet:grid-col-3">
+        <aside class="usa-layout-docs__sidenav desktop:grid-col-3">
           <nav>
             <ul class="usa-sidenav">
               {% include nav/list.html
@@ -18,7 +18,7 @@ layout: base
           </nav>
         </aside>
 
-        <div class="usa-layout-docs__main tablet:grid-col-9 usa-prose">
+        <div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">
 
           {% if site.temporary_alert %}
             {% include alert.html content=site.temporary_alert %}
@@ -34,7 +34,7 @@ layout: base
         </div>
       </div>
     {% else %}
-      <div class="usa-layout-docs__main tablet:grid-col-9 usa-prose">
+      <div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">
 
         {% if site.temporary_alert %}
           {% include alert.html content=site.temporary_alert %}

--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -1,4 +1,4 @@
-@import "identity-style-guide/dist/assets/scss/packages/required";
+@use "uswds-core" as *;
 
 .usa-prose {
   figure {
@@ -16,10 +16,6 @@
       font-size: 0.8em;
     }
   }
-}
-
-#nav-links {
-  width: fit-content !important;
 }
 
 .reversefootnote {

--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -1,4 +1,10 @@
-@use "uswds-core" as *;
+@use "uswds-core" as * with (
+  $theme-utility-breakpoints: (
+    "tablet": true,
+    "desktop": true,
+  )
+);
+@forward "uswds";
 
 .usa-prose {
   figure {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "CC0-1.0",
       "dependencies": {
         "@18f/identity-build-sass": "^1.1.0",
-        "@18f/identity-design-system": "^7.0.1-beta.1"
+        "@18f/identity-design-system": "^7.0.1"
       }
     },
     "node_modules/@18f/identity-build-sass": {
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@18f/identity-design-system": {
-      "version": "7.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.0.1-beta.1.tgz",
-      "integrity": "sha512-blJhBPG7QXZH3B8CaMR95DWDfRDy9KLYKUkJzgzUkN+w5NVUovJmdv1B/SaEw6Vvr8cBV1/Ovo1h/jLq50+mPA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.0.1.tgz",
+      "integrity": "sha512-5KblBGmHLrsLGsF0cCThnkBWG0ZK+sP9NQln4FyEYXs0dzzGr0duhtqnMfGUZr6dj6ziZZjFCTmP8WNlkkpclA==",
       "dependencies": {
         "@uswds/uswds": "^3.4.1"
       },
@@ -762,9 +762,9 @@
       }
     },
     "@18f/identity-design-system": {
-      "version": "7.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.0.1-beta.1.tgz",
-      "integrity": "sha512-blJhBPG7QXZH3B8CaMR95DWDfRDy9KLYKUkJzgzUkN+w5NVUovJmdv1B/SaEw6Vvr8cBV1/Ovo1h/jLq50+mPA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.0.1.tgz",
+      "integrity": "sha512-5KblBGmHLrsLGsF0cCThnkBWG0ZK+sP9NQln4FyEYXs0dzzGr0duhtqnMfGUZr6dj6ziZZjFCTmP8WNlkkpclA==",
       "requires": {
         "@uswds/uswds": "^3.4.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "CC0-1.0",
       "dependencies": {
         "@18f/identity-build-sass": "^1.1.0",
-        "identity-style-guide": "^6.7.0"
+        "@18f/identity-design-system": "^7.0.1-beta.1"
       }
     },
     "node_modules/@18f/identity-build-sass": {
@@ -27,10 +27,36 @@
         "build-sass": "cli.js"
       }
     },
+    "node_modules/@18f/identity-design-system": {
+      "version": "7.0.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.0.1-beta.1.tgz",
+      "integrity": "sha512-blJhBPG7QXZH3B8CaMR95DWDfRDy9KLYKUkJzgzUkN+w5NVUovJmdv1B/SaEw6Vvr8cBV1/Ovo1h/jLq50+mPA==",
+      "dependencies": {
+        "@uswds/uswds": "^3.4.1"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">6"
+      }
+    },
     "node_modules/@bufbuild/protobuf": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.2.0.tgz",
       "integrity": "sha512-MBVuQMOBHxgGnZ9XCUIi8WOy5O/T4ma3TduCRhRvndv3UDbG9cHgd8h6nOYSGyBYPEvXf1z9nTwhp8mVIDbq2g=="
+    },
+    "node_modules/@uswds/uswds": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.4.1.tgz",
+      "integrity": "sha512-eLYbWUqf9eWUa2P6CO3ckIjtQyM3AylrIOHxN5gYG3P62TDd3FzRDyoACfvOe6CNk0w0PqXWJnuPzxpNoOgWNA==",
+      "dependencies": {
+        "classlist-polyfill": "1.0.3",
+        "object-assign": "4.1.1",
+        "receptor": "1.0.0",
+        "resolve-id-refs": "0.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -156,11 +182,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/domready": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/domready/-/domready-1.0.8.tgz",
-      "integrity": "sha512-uIzsOJUNk+AdGE9a6VDeessoMCzF8RrZvJCX/W8QtyfgdR6Uofn/MvRonih3OtCO79b2VDzDOymuiABrQ4z3XA=="
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.348",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.348.tgz",
@@ -223,19 +244,6 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/identity-style-guide": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/identity-style-guide/-/identity-style-guide-6.7.0.tgz",
-      "integrity": "sha512-kXITvbEJWlj7fjSLVbeqZ7hnQ20RL51VFFoANojbVChVeVebOeyb3NIAX9mQ1sIVS34ycnKypM/jdoHmj4Dh/g==",
-      "dependencies": {
-        "domready": "1.0.8",
-        "uswds": "^2.13.3"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">6"
       }
     },
     "node_modules/immutable": {
@@ -739,21 +747,6 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
-    },
-    "node_modules/uswds": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.13.3.tgz",
-      "integrity": "sha512-qCblljeaRvS3+PrSxoHqQwmMnp746+Y1YZA34BkTzJknvo2bhhdzGE21yJaInumzIqV3glLD13TFdRwrwikMMQ==",
-      "dependencies": {
-        "classlist-polyfill": "1.0.3",
-        "domready": "1.0.8",
-        "object-assign": "4.1.1",
-        "receptor": "1.0.0",
-        "resolve-id-refs": "0.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
     }
   },
   "dependencies": {
@@ -768,10 +761,29 @@
         "sass-embedded": "^1.56.1"
       }
     },
+    "@18f/identity-design-system": {
+      "version": "7.0.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.0.1-beta.1.tgz",
+      "integrity": "sha512-blJhBPG7QXZH3B8CaMR95DWDfRDy9KLYKUkJzgzUkN+w5NVUovJmdv1B/SaEw6Vvr8cBV1/Ovo1h/jLq50+mPA==",
+      "requires": {
+        "@uswds/uswds": "^3.4.1"
+      }
+    },
     "@bufbuild/protobuf": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.2.0.tgz",
       "integrity": "sha512-MBVuQMOBHxgGnZ9XCUIi8WOy5O/T4ma3TduCRhRvndv3UDbG9cHgd8h6nOYSGyBYPEvXf1z9nTwhp8mVIDbq2g=="
+    },
+    "@uswds/uswds": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.4.1.tgz",
+      "integrity": "sha512-eLYbWUqf9eWUa2P6CO3ckIjtQyM3AylrIOHxN5gYG3P62TDd3FzRDyoACfvOe6CNk0w0PqXWJnuPzxpNoOgWNA==",
+      "requires": {
+        "classlist-polyfill": "1.0.3",
+        "object-assign": "4.1.1",
+        "receptor": "1.0.0",
+        "resolve-id-refs": "0.1.0"
+      }
     },
     "anymatch": {
       "version": "3.1.3",
@@ -841,11 +853,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="
     },
-    "domready": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/domready/-/domready-1.0.8.tgz",
-      "integrity": "sha512-uIzsOJUNk+AdGE9a6VDeessoMCzF8RrZvJCX/W8QtyfgdR6Uofn/MvRonih3OtCO79b2VDzDOymuiABrQ4z3XA=="
-    },
     "electron-to-chromium": {
       "version": "1.4.348",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.348.tgz",
@@ -887,15 +894,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-    },
-    "identity-style-guide": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/identity-style-guide/-/identity-style-guide-6.7.0.tgz",
-      "integrity": "sha512-kXITvbEJWlj7fjSLVbeqZ7hnQ20RL51VFFoANojbVChVeVebOeyb3NIAX9mQ1sIVS34ycnKypM/jdoHmj4Dh/g==",
-      "requires": {
-        "domready": "1.0.8",
-        "uswds": "^2.13.3"
-      }
     },
     "immutable": {
       "version": "4.3.0",
@@ -1155,18 +1153,6 @@
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
-      }
-    },
-    "uswds": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.13.3.tgz",
-      "integrity": "sha512-qCblljeaRvS3+PrSxoHqQwmMnp746+Y1YZA34BkTzJknvo2bhhdzGE21yJaInumzIqV3glLD13TFdRwrwikMMQ==",
-      "requires": {
-        "classlist-polyfill": "1.0.3",
-        "domready": "1.0.8",
-        "object-assign": "4.1.1",
-        "receptor": "1.0.0",
-        "resolve-id-refs": "0.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/18F/identity-dev-docs#readme",
   "dependencies": {
     "@18f/identity-build-sass": "^1.1.0",
-    "@18f/identity-design-system": "^7.0.1-beta.1"
+    "@18f/identity-design-system": "^7.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "prebuild:css": "mkdir -p _site/assets/css",
-    "build:css": "build-sass assets/scss/*.scss --out-dir=_site/assets/css",
+    "build:css": "build-sass assets/scss/*.scss --out-dir=_site/assets/css --load-path=node_modules/@18f/identity-design-system/packages",
     "watch:css": "npm run build:css -- --watch",
     "pages": "npm run build:css"
   },
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/18F/identity-dev-docs#readme",
   "dependencies": {
     "@18f/identity-build-sass": "^1.1.0",
-    "identity-style-guide": "^6.7.0"
+    "@18f/identity-design-system": "^7.0.1-beta.1"
   }
 }


### PR DESCRIPTION
## 🛠 Summary of changes

Upgrades the version of the Login.gov Design System from 6.7.0 to 7.0.1.

Primarily, this involves:

- Upgrading USWDS v2 to v3
- Migrating Sass syntax to new Dart-based `@use` & `@forward`

## 📜 Testing Plan

Preview link: https://federalist-14ccf384-8bd5-4e30-aa95-a5fe5894e3c1.sites.pages.cloud.gov/preview/18f/identity-dev-docs/aduth-lgds-7/

For changes introduced in the 7.0.1 release of the Login.gov Design System, it's worth special attention to navigation (both desktop and mobile), which received a significant refactor.