### PR TITLE
Update largest heading to be H1 instead of DIV

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -8,7 +8,7 @@ layout: home
 
 <section class="usa-section usa-section--dark">
   <div class="grid-container">
-    <div class="usa-display">{{ page.title }}</div>
+    <h1 class="usa-display">{{ page.title }}</h1>
     <div class="usa-intro">{{ page.lead | markdownify }}</div>
   </div>
 </section>


### PR DESCRIPTION
### Relevant Ticket

[LG-9645](https://cm-jira.usa.gov/browse/LG-9645)

### Description of Changes

Updates `<div class="usa-display">` to be `<h1 class="usa-display">`, which updates the largest texts from divs to h1 for accessibility changes. Since the class remained the same, the UI has no changes.

<img width="1369" alt="image" src="https://github.com/18F/identity-dev-docs/assets/2308626/bdffa94f-393e-46b0-8e43-a62720a5d0c3">

<img width="1369" alt="image" src="https://github.com/18F/identity-dev-docs/assets/2308626/67e0c75f-4023-4033-8f02-d23e75d8dc57">

<img width="1369" alt="image" src="https://github.com/18F/identity-dev-docs/assets/2308626/397a5656-8a6b-424a-bda1-a5219272364f">

