### PR TITLE
Add jekyll-sitemap to config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'jekyll', '~> 4.3.0'
 gem 'jekyll-sass-converter', '~> 3.0.0'
 gem 'kramdown-parser-gfm', '~> 1.0'
 gem 'jekyll-redirect-from'
+gem 'jekyll-sitemap'
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,8 @@ GEM
       jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.4.0)
@@ -90,6 +92,7 @@ DEPENDENCIES
   jekyll (~> 4.3.0)
   jekyll-redirect-from
   jekyll-sass-converter (~> 3.0.0)
+  jekyll-sitemap
   kramdown-parser-gfm (~> 1.0)
   nokogiri (>= 1.10.5)
   rspec

--- a/_config.yml
+++ b/_config.yml
@@ -8,9 +8,11 @@ temporary_alert: false
 
 plugins:
   - jekyll-redirect-from
+  - jekyll-sitemap
 
 whitelist:
   - jekyll-redirect-from
+  - jekyll-sitemap
 
 copy_to_destination:
   - node_modules/@18f/identity-design-system/dist/assets


### PR DESCRIPTION
Relevant ticket: 
https://cm-jira.usa.gov/browse/LG-9606

Change notes:
This change adds the[ jekyll-sitemap](https://github.com/jekyll/jekyll-sitemap) plugin which will automatically generate a sitemap for the developer docs. This is necessary to utilize search.gov.