### PR TITLE
Updates to support page content

### DIFF
--- a/_pages/support.md
+++ b/_pages/support.md
@@ -433,7 +433,7 @@ The signature could be sent in one of two ways:
 </div>
 
 If the <b>Signature</b> and <b>SigAlg</b> URL parameters (and associated values) are present, your authentication request is signed.
-If the signature is not part of the URL, it may be part of the SAML request. To check this, you will need to decode the data sent via the <b>SAMLRequest</b> parameter. The easiest way to do this is the "SAML Tracer" browser plugin. Our <a class="usa-link" href="http://dashboard.int.identitysandbox.gov/tools">a web-based tool</a> can also help with this. Once decoded, you should see a section that contains all the relevant signature-related information and should be enclosed in a tag like:
+If the signature is not part of the URL, it may be part of the SAML request. To check this, you will need to decode the data sent via the <b>SAMLRequest</b> parameter. The easiest way to do this is the "SAML Tracer" browser plugin. Our <a class="usa-link" href="http://dashboard.int.identitysandbox.gov/tools">web-based tool</a> can also help with this. Once decoded, you should see a section that contains all the relevant signature-related information and should be enclosed in a tag like:
 
 ```
 <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">

--- a/_pages/support.md
+++ b/_pages/support.md
@@ -411,4 +411,61 @@ SAML requests from browser consoles are URI encoded, base-64-encoded, and deflat
 </div>
 </div>
 
+<h4 class="usa-accordion__heading">
+<button class="usa-accordion__button" aria-controls="tipstools">
+SAML Signature Troubleshooting
+</button>
+</h4>
+<div id="tipstools" class="usa-accordion__container">
+<div class="usa-accordion__content" markdown="1"  aria-expanded="true">
+Login.gov uses the cryptographic signatures of authentication requests to determine which public certificate to use when encrypting data in the SAML response. If the signature is not present, or cannot be validated successfully, you will encounter problems when you rotate your application’s key pair.
+
+<b> Check signature is present </b>
+
+If you are not sure whether your application is currently signing authentication requests, the easiest way to check is through the network tab in your browser's developer tools. Look for the URL generated when your app sends the user to Login.gov's sign-in page.
+
+The signature could be sent in one of two ways:
+<div>
+<ol class="usa-list">
+      <li>As a parameter within the URL,</li>
+      <li>or as a field within the authentication request’s SAML data.</li>
+    </ol>
+  </div>
+
+If the <b>Signature</b> and <b>SigAlg</b> URL parameters (and associated values) are present, your authentication request is signed.
+If the signature is not part of the URL, it may be part of the SAML request. To check this, you will need to decode the data sent via the <b>SAMLRequest</b> parameter. The easiest way to do this is the "SAML Tracer" browser plugin. Our <a class="usa-link" href="http://dashboard.int.identitysandbox.gov/tools">a web-based tool</a> can also help with this. Once decoded, you should see a section that contains all the relevant signature-related information and should be enclosed in a tag like:
+
+<code><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"></code>
+
+<div class="usa-alert usa-alert--warning">
+  <div class="usa-alert__body">
+    <h4 class="usa-alert__heading">Warning status</h4>
+    <p class="usa-alert__text">
+        If there is no indication of a signature within the request URL or the request SAML, the request is not signed.
+    </p>
+  </div>
+</div>
+
+
+<b>Check the signature algorithm</b>
+
+One common reason for failing signature validation is the use of an unsupported hashing algorithm, like SHA1. <b>Login.gov only supports SHA256.</b> Using the methods described above, check whether your request either contains a SigAlg parameter indicating the use of SHA256, or your SAML includes a tag indicating this, for example:
+
+<code><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" /></code>
+
+<b>Check validity of signature</b>
+
+There may be other reasons Login.gov cannot successfully validate your application’s signatures using the information you have provided in the Login.gov Partner Dashboard for the application. We have created a <a class="usa-link" href="http://dashboard.int.identitysandbox.gov/tools">a web-based tool</a> that lets you check this easily. The following items must be provided to check the signature:
+<ul class="usa-list">
+<li> <b>Auth URL</b>: Paste the entire auth URL here (it should include parameters like SAMLRequest, Signature, SigAlg etc). If there is no Signature parameter in the URL, you can also only paste the value of the <b>SAMLRequest</b> parameter here.</li>
+                  
+<li> <b>Public Certificate</b>: Optionally, you can paste the public certificate (in PEM format) you want to check the signature against. If not provided, we will attempt to use the certificates you have added to your application’s configuration.</li>
+</ul>
+
+If you find your signature cannot be validated using this process, you will have to investigate what may be causing these problems and make changes on your side until validation succeeds.
+
+
+</div>
+</div>
+
 </div>

--- a/_pages/support.md
+++ b/_pages/support.md
@@ -361,9 +361,7 @@ Supported browsers
 </h4>
 <div id="csp" class="usa-accordion__container">
 <div class="usa-accordion__content" markdown="1"  aria-expanded="true">
-<p>  
 Login.gov uses the <a class="usa-link" href="https://designsystem.digital.gov/">a US Web Design System (USWDS) </a> components on our websites. The current version (USWDS 3.0.0) supports the newest versions of Chrome, Firefox, and Safari. Internet Explorer 11 (IE11) is no longer officially supported and therefore is not recommended for use with Login.gov. If you experience issues connecting with Login.gov, try using one of the recommended browsers before contacting technical support.  
-</p>
 </div>
 </div>
 
@@ -418,8 +416,7 @@ SAML Signature Troubleshooting
 </button>
 </h4>
 <div id="tipstools" class="usa-accordion__container">
-<div class="usa-accordion__content" markdown="1"  aria-expanded="true">
-<p>  
+<div class="usa-accordion__content" markdown="1"  aria-expanded="true"> 
 Login.gov uses the cryptographic signatures of authentication requests to determine which public certificate to use when encrypting data in the SAML response. If the signature is not present, or cannot be validated successfully, you will encounter problems when you rotate your application’s key pair.
 
 <b> Check signature is present </b>
@@ -453,7 +450,7 @@ If the signature is not part of the URL, it may be part of the SAML request. To 
 
 One common reason for failing signature validation is the use of an unsupported hashing algorithm, like SHA1. <b>Login.gov only supports SHA256.</b> Using the methods described above, check whether your request either contains a SigAlg parameter indicating the use of SHA256, or your SAML includes a tag indicating this, for example:
 
-<code> <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" /> </code>
+ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" /
 
 <b>Check validity of signature</b>
 
@@ -465,7 +462,6 @@ There may be other reasons Login.gov cannot successfully validate your applicati
 </ul>
 
 If you find your signature cannot be validated using this process, you will have to investigate what may be causing these problems and make changes on your side until validation succeeds.
-</p>
 
 </div>
 </div>

--- a/_pages/support.md
+++ b/_pages/support.md
@@ -353,6 +353,7 @@ This error occurs when Service Providers attempt to redirect users to a url that
 
 Use the Network tab of your web browser to identify which redirect (302) is hanging or failing. Add that uri to the list of Redirect URIs in your Login.gov Dashboard configuration.
 </div>
+</div>
 
 <h4 class="usa-accordion__heading">
 <button class="usa-accordion__button" aria-controls="csp">

--- a/_pages/support.md
+++ b/_pages/support.md
@@ -435,7 +435,9 @@ The signature could be sent in one of two ways:
 If the <b>Signature</b> and <b>SigAlg</b> URL parameters (and associated values) are present, your authentication request is signed.
 If the signature is not part of the URL, it may be part of the SAML request. To check this, you will need to decode the data sent via the <b>SAMLRequest</b> parameter. The easiest way to do this is the "SAML Tracer" browser plugin. Our <a class="usa-link" href="http://dashboard.int.identitysandbox.gov/tools">a web-based tool</a> can also help with this. Once decoded, you should see a section that contains all the relevant signature-related information and should be enclosed in a tag like:
 
-<code> <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"> </code>
+```
+<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+```
 
 <div class="usa-alert usa-alert--warning">
   <div class="usa-alert__body">
@@ -451,7 +453,9 @@ If the signature is not part of the URL, it may be part of the SAML request. To 
 
 One common reason for failing signature validation is the use of an unsupported hashing algorithm, like SHA1. <b>Login.gov only supports SHA256.</b> Using the methods described above, check whether your request either contains a SigAlg parameter indicating the use of SHA256, or your SAML includes a tag indicating this, for example:
 
-ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" /
+```
+<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+```
 
 <b>Check validity of signature</b>
 

--- a/_pages/support.md
+++ b/_pages/support.md
@@ -356,12 +356,12 @@ Use the Network tab of your web browser to identify which redirect (302) is hang
 </div>
 
 <h4 class="usa-accordion__heading">
-<button class="usa-accordion__button" aria-controls="csp">
+<button class="usa-accordion__button" aria-controls="supportedbrowsers">
 Supported browsers
 </button>
 </h4>
-<div id="csp" class="usa-accordion__container">
-<div class="usa-accordion__content" markdown="1"  aria-expanded="true">
+<div id="supportedbrowsers" class="usa-accordion__container">
+<div class="usa-accordion__content" markdown="1">
 Login.gov uses the <a class="usa-link" href="https://designsystem.digital.gov/">a US Web Design System (USWDS) </a> components on our websites. The current version (USWDS 3.0.0) supports the newest versions of Chrome, Firefox, and Safari. Internet Explorer 11 (IE11) is no longer officially supported and therefore is not recommended for use with Login.gov. If you experience issues connecting with Login.gov, try using one of the recommended browsers before contacting technical support.  
 </div>
 </div>
@@ -412,11 +412,11 @@ SAML requests from browser consoles are URI encoded, base-64-encoded, and deflat
 </div>
 
 <h4 class="usa-accordion__heading">
-<button class="usa-accordion__button" aria-controls="tipstools">
+<button class="usa-accordion__button" aria-controls="samlsignaturetroubleshooting">
 SAML Signature Troubleshooting
 </button>
 </h4>
-<div id="tipstools" class="usa-accordion__container">
+<div id="samlsignaturetroubleshooting" class="usa-accordion__container">
 <div class="usa-accordion__content" markdown="1"  aria-expanded="true"> 
 Login.gov uses the cryptographic signatures of authentication requests to determine which public certificate to use when encrypting data in the SAML response. If the signature is not present, or cannot be validated successfully, you will encounter problems when you rotate your application’s key pair.
 

--- a/_pages/support.md
+++ b/_pages/support.md
@@ -15,6 +15,14 @@ sidenav:
       - text: Other Tips & Tools
         href: "#other-tips--tools"
 ---
+### Login.gov support desk
+
+If you have techinical questions that are not covered by these FAQ's, submit a ticket to the <a
+    class="usa-link usa-link--external"
+    rel="noreferrer"
+    target="_blank"
+    href="https://zendesk.login.gov"
+    >Partner Support Help Desk</a>.
 
 ## Frequently Asked Questions
 

--- a/_pages/support.md
+++ b/_pages/support.md
@@ -355,6 +355,17 @@ Use the Network tab of your web browser to identify which redirect (302) is hang
 </div>
 </div>
 
+<h4 class="usa-accordion__heading">
+<button class="usa-accordion__button" aria-controls="csp">
+Supported browsers
+</button>
+</h4>
+<div id="csp" class="usa-accordion__container">
+<div class="usa-accordion__content" markdown="1"  aria-expanded="true">
+Login.gov uses the <a class="usa-link" href="https://designsystem.digital.gov/">a US Web Design System (USWDS) </a> components on our websites. The current version (USWDS 3.0.0) supports the newest versions of Chrome, Firefox, and Safari. Internet Explorer 11 (IE11) is no longer officially supported and therefore is not recommended for use with Login.gov. If you experience issues connecting with Login.gov, try using one of the recommended browsers before contacting technical support.  
+</div>
+</div>
+
 </div>
 
 ### Other Application Issues

--- a/_pages/support.md
+++ b/_pages/support.md
@@ -353,7 +353,6 @@ This error occurs when Service Providers attempt to redirect users to a url that
 
 Use the Network tab of your web browser to identify which redirect (302) is hanging or failing. Add that uri to the list of Redirect URIs in your Login.gov Dashboard configuration.
 </div>
-</div>
 
 <h4 class="usa-accordion__heading">
 <button class="usa-accordion__button" aria-controls="csp">
@@ -362,7 +361,9 @@ Supported browsers
 </h4>
 <div id="csp" class="usa-accordion__container">
 <div class="usa-accordion__content" markdown="1"  aria-expanded="true">
+<p>  
 Login.gov uses the <a class="usa-link" href="https://designsystem.digital.gov/">a US Web Design System (USWDS) </a> components on our websites. The current version (USWDS 3.0.0) supports the newest versions of Chrome, Firefox, and Safari. Internet Explorer 11 (IE11) is no longer officially supported and therefore is not recommended for use with Login.gov. If you experience issues connecting with Login.gov, try using one of the recommended browsers before contacting technical support.  
+</p>
 </div>
 </div>
 
@@ -418,6 +419,7 @@ SAML Signature Troubleshooting
 </h4>
 <div id="tipstools" class="usa-accordion__container">
 <div class="usa-accordion__content" markdown="1"  aria-expanded="true">
+<p>  
 Login.gov uses the cryptographic signatures of authentication requests to determine which public certificate to use when encrypting data in the SAML response. If the signature is not present, or cannot be validated successfully, you will encounter problems when you rotate your application’s key pair.
 
 <b> Check signature is present </b>
@@ -435,7 +437,7 @@ The signature could be sent in one of two ways:
 If the <b>Signature</b> and <b>SigAlg</b> URL parameters (and associated values) are present, your authentication request is signed.
 If the signature is not part of the URL, it may be part of the SAML request. To check this, you will need to decode the data sent via the <b>SAMLRequest</b> parameter. The easiest way to do this is the "SAML Tracer" browser plugin. Our <a class="usa-link" href="http://dashboard.int.identitysandbox.gov/tools">a web-based tool</a> can also help with this. Once decoded, you should see a section that contains all the relevant signature-related information and should be enclosed in a tag like:
 
-<code><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"></code>
+<code> <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"> </code>
 
 <div class="usa-alert usa-alert--warning">
   <div class="usa-alert__body">
@@ -451,7 +453,7 @@ If the signature is not part of the URL, it may be part of the SAML request. To 
 
 One common reason for failing signature validation is the use of an unsupported hashing algorithm, like SHA1. <b>Login.gov only supports SHA256.</b> Using the methods described above, check whether your request either contains a SigAlg parameter indicating the use of SHA256, or your SAML includes a tag indicating this, for example:
 
-<code><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" /></code>
+<code> <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" /> </code>
 
 <b>Check validity of signature</b>
 
@@ -463,7 +465,7 @@ There may be other reasons Login.gov cannot successfully validate your applicati
 </ul>
 
 If you find your signature cannot be validated using this process, you will have to investigate what may be causing these problems and make changes on your side until validation succeeds.
-
+</p>
 
 </div>
 </div>

--- a/_pages/support.md
+++ b/_pages/support.md
@@ -17,7 +17,7 @@ sidenav:
 ---
 ### Login.gov support desk
 
-If you have techinical questions that are not covered by these FAQ's, submit a ticket to the <a
+If you have technical questions that are not covered by these FAQ's, submit a ticket to the <a
     class="usa-link usa-link--external"
     rel="noreferrer"
     target="_blank"

--- a/_pages/support.md
+++ b/_pages/support.md
@@ -441,7 +441,7 @@ If the signature is not part of the URL, it may be part of the SAML request. To 
 
 <div class="usa-alert usa-alert--warning">
   <div class="usa-alert__body">
-    <h4 class="usa-alert__heading">Warning status</h4>
+    <h4 class="usa-alert__heading"></h4>
     <p class="usa-alert__text">
         If there is no indication of a signature within the request URL or the request SAML, the request is not signed.
     </p>
@@ -459,7 +459,7 @@ One common reason for failing signature validation is the use of an unsupported 
 
 <h5>Check validity of signature</h5>
 
-There may be other reasons Login.gov cannot successfully validate your application’s signatures using the information you have provided in the Login.gov Partner Dashboard for the application. We have created a <a class="usa-link" href="http://dashboard.int.identitysandbox.gov/tools">a web-based tool</a> that lets you check this easily. The following items must be provided to check the signature:
+There may be other reasons Login.gov cannot successfully validate your application’s signatures using the information you have provided in the Login.gov Partner Dashboard for the application. We have created a <a class="usa-link" href="http://dashboard.int.identitysandbox.gov/tools"> web-based tool</a> that lets you check this easily. The following items must be provided to check the signature:
 <ul class="usa-list">
 <li> <b>Auth URL</b>: Paste the entire auth URL here (it should include parameters like SAMLRequest, Signature, SigAlg etc). If there is no Signature parameter in the URL, you can also only paste the value of the <b>SAMLRequest</b> parameter here.</li>
                   

--- a/_pages/support.md
+++ b/_pages/support.md
@@ -420,17 +420,17 @@ SAML Signature Troubleshooting
 <div class="usa-accordion__content" markdown="1"  aria-expanded="true"> 
 Login.gov uses the cryptographic signatures of authentication requests to determine which public certificate to use when encrypting data in the SAML response. If the signature is not present, or cannot be validated successfully, you will encounter problems when you rotate your application’s key pair.
 
-<b> Check signature is present </b>
+<h5> Check signature is present </h5>
 
 If you are not sure whether your application is currently signing authentication requests, the easiest way to check is through the network tab in your browser's developer tools. Look for the URL generated when your app sends the user to Login.gov's sign-in page.
 
 The signature could be sent in one of two ways:
 <div>
-<ol class="usa-list">
+    <ol class="usa-list">
       <li>As a parameter within the URL,</li>
       <li>or as a field within the authentication request’s SAML data.</li>
     </ol>
-  </div>
+</div>
 
 If the <b>Signature</b> and <b>SigAlg</b> URL parameters (and associated values) are present, your authentication request is signed.
 If the signature is not part of the URL, it may be part of the SAML request. To check this, you will need to decode the data sent via the <b>SAMLRequest</b> parameter. The easiest way to do this is the "SAML Tracer" browser plugin. Our <a class="usa-link" href="http://dashboard.int.identitysandbox.gov/tools">a web-based tool</a> can also help with this. Once decoded, you should see a section that contains all the relevant signature-related information and should be enclosed in a tag like:
@@ -449,7 +449,7 @@ If the signature is not part of the URL, it may be part of the SAML request. To 
 </div>
 
 
-<b>Check the signature algorithm</b>
+<h5>Check the signature algorithm</h5>
 
 One common reason for failing signature validation is the use of an unsupported hashing algorithm, like SHA1. <b>Login.gov only supports SHA256.</b> Using the methods described above, check whether your request either contains a SigAlg parameter indicating the use of SHA256, or your SAML includes a tag indicating this, for example:
 
@@ -457,7 +457,7 @@ One common reason for failing signature validation is the use of an unsupported 
 <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
 ```
 
-<b>Check validity of signature</b>
+<h5>Check validity of signature</h5>
 
 There may be other reasons Login.gov cannot successfully validate your application’s signatures using the information you have provided in the Login.gov Partner Dashboard for the application. We have created a <a class="usa-link" href="http://dashboard.int.identitysandbox.gov/tools">a web-based tool</a> that lets you check this easily. The following items must be provided to check the signature:
 <ul class="usa-list">


### PR DESCRIPTION
One commit for three jira ticketed updates: 

- [LG-9863](https://cm-jira.usa.gov/browse/LG-9863) add zendesk information to the FAQ page. User research showed that the support page was often the first place users went to find help desk info. 
- [LG-9831](https://cm-jira.usa.gov/browse/LG-9831) add [browser support statement](https://docs.google.com/document/d/1VUHI5MqpTyfYvbTlnqKGhzUQ4wtCP6FDMGPFm-eIwl8/edit?usp=sharing) to FAQ page. 
- [LG-9507](https://cm-jira.usa.gov/browse/LG-9507) add SAML signature troubleshooting to support page