### PR TITLE
LG-10165 fix alert icon only being 2px tall 

### DIFF
--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -22,6 +22,11 @@
       font-size: 0.8em;
     }
   }
+
+// Upstream fix: https://github.com/uswds/uswds/pull/5187
+.usa-alert .usa-alert__body::before {
+    height: units(2);
+  }
 }
 
 .reversefootnote {


### PR DESCRIPTION
[LG-10165](https://cm-jira.usa.gov/browse/LG-10165)

This issue was [caused by a change to uswds code](https://github.com/18F/identity-idp/pull/8093#issuecomment-1508523490), and a [patch fix](https://github.com/18F/identity-idp/commit/efc6876f8ec55a81075c35367bdb96f5a08e6174) was already added in to identity-idp.

I used the same type of patch code that was added to identity-idp for the fix. 
