### PR TITLE
LG-9607 add search functionality

### DIFF
--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,0 +1,16 @@
+<!-- borrowed heavily from https://github.com/18F/identity-site/blob/main/_includes/search.html -->
+<form
+  accept-charset="UTF-8"
+  action="https://search.usa.gov/search"
+  class="usa-search{% if include.size %} usa-search--{{ include.size }}{% endif %}"
+  id="search_form"
+  method="get"
+  role="search"
+>
+  <input name="utf8" type="hidden" value="&#x2713;" />
+  <input type="hidden" name="affiliate" id="affiliate" value="developers-login-gov" autocomplete="off" />
+  <input type="search" name="query" id="search-field-{{ include.id }}" autocomplete="off" class="usa-input" />
+  <button class="usa-button" type="submit" name="commit" value="Search" data-disable-with="Search">
+    <span class="usa-search__submit-text">Search</span>
+  </button>
+</form>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -99,10 +99,6 @@
             <em class="usa-logo__text">Developers</em>
           </a>
         </div>
-        <div>
-          {% include search.html id="header-nav" %}
-        </div>
-
         <button class="usa-menu-btn">Menu</button>
       </div>
       <nav role="navigation" class="usa-nav border-top-none">
@@ -110,6 +106,12 @@
           <button class="usa-nav__close">
             <img src="{{ site.baseurl }}/assets/img/close.svg" alt="Close" role="img">
           </button>
+          <div class="usa-nav__secondary">
+            <ul class="usa-nav__secondary-links"></ul>
+            <section aria-label="Search component">
+              {% include search.html id="header-nav" %}
+            </section>
+          </div>
           <ul class="usa-nav__primary usa-accordion">
             {% include nav/list.html
               links = site.data.nav.primary

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -99,6 +99,10 @@
             <em class="usa-logo__text">Developers</em>
           </a>
         </div>
+        <div>
+          {% include search.html id="header-nav" %}
+        </div>
+
         <button class="usa-menu-btn">Menu</button>
       </div>
       <nav role="navigation" class="usa-nav border-top-none">


### PR DESCRIPTION
### Ticket: 
https://cm-jira.usa.gov/browse/LG-9607

### Changes:
This change adds a search component to the header. 

See attached pics, which can be compared to the [figma design](https://www.figma.com/file/HHD28cToRlcOcqYcrFIm2o/Login.gov-Developer-Guide-(LG-9258%2C-LG-9244)?type=design&node-id=8-983&mode=design)

 Full screen header:
<img width="1032" alt="Full screen Login.gov development docs header with search component" src="https://github.com/18F/identity-dev-docs/assets/5473830/f478155d-76ac-48e4-89af-8a4245c645a0">

Tablet/mobile view:
<img width="451" alt="tablet/mobile view of menu bar with search component" src="https://github.com/18F/identity-dev-docs/assets/5473830/2c279411-65ec-42a4-8f01-fd23ccd3ad3a">

Search page with different tab options
<img width="984" alt="Login.gov branded view of search results" src="https://github.com/18F/identity-dev-docs/assets/5473830/b0d57666-96d8-4b14-bcb0-006c0fea2702">

Search page with browse site menu options opened
<img width="1161" alt="Login.gov branded view with links corresponding to develop docs navigation" src="https://github.com/18F/identity-dev-docs/assets/5473830/c51fe960-54eb-4ba0-8938-848b5b218999">


