### PR TITLE
Stricter wording in dev docs about automated tests

### DIFF
--- a/_pages/testing.md
+++ b/_pages/testing.md
@@ -36,11 +36,11 @@ Make sure you're using the corresponding private key in your application to sign
 
 ## Load Testing
 
-Our sandbox environment is smaller than our production environment and it is shared by many of our partners. It has not been configured for load testing and is likely to crash. **For these reasons, our reccomendation is to mock out the Login.gov portion of your load tests.** We thoroughly load test our infrastructure and can provide data on our capabilities upon request.
+Our sandbox environment is smaller than our production environment and it is shared by many of our partners. It has not been configured for load testing and is likely to crash. **For these reasons, our recommendation is to mock out the Login.gov portion of your load tests.** We thoroughly load test our infrastructure and can provide data on our capabilities upon request.
 
 ## Automated Testing
 
-**Similar to load testing, we strongly reccomend stubbing out the portion of your tests that require signing a user into Login.gov or creating an account.** This is especially true for applications using identity verification, because we are frequently making updates to the code and the flow is likely to change and could unexpectedly break your tests. 
+**Similar to load testing, we strongly recommend stubbing out the portion of your tests that require signing a user into Login.gov or creating an account.** This is especially true for applications using identity verification, because we are frequently making updates to the code and the flow is likely to change and could unexpectedly break your tests. 
 
 If you are looking for reccomendations for automated testing, we do not have any specific advice. There are many different frameworks and automated testing suites available to choose from, and our partners usually pick based on their own unique needs. Regardless of which suite you choose, it should be noted that you cannot bypass the MFA portion of the flow. It is intentionally designed this way for security purposes and another reason why we reccomend stubbing out our flow. 
 

--- a/_pages/testing.md
+++ b/_pages/testing.md
@@ -40,9 +40,9 @@ Our sandbox environment is smaller than our production environment and it is sha
 
 ## Automated Testing
 
-**Similar to load testing, we strongly recommend stubbing out the portion of your tests that require signing a user into Login.gov or creating an account.** This is especially true for applications using identity verification, because we are frequently making updates to the code and the flow is likely to change and could unexpectedly break your tests. 
+**Login.gov cannot provide specific recommendations for automated testing.** This is especially true for applications using identity verification, because we are frequently making updates to the code and the flow is likely to change and could unexpectedly break your tests. 
 
-If you are looking for recommendations for automated testing, we do not have any specific advice. There are many different frameworks and automated testing suites available to choose from, and our partners usually pick based on their own unique needs. Regardless of which suite you choose, it should be noted that you cannot bypass the MFA portion of the flow. It is intentionally designed this way for security purposes and another reason why we recommend stubbing out our flow. 
+If you are looking for recommendations for automated testing, we do not have any specific advice. There are many different frameworks and automated testing suites available to choose from, and our partners usually pick based on their own unique needs. **Regardless of which suite you choose, it should be noted that you cannot bypass the MFA portion of the flow.** It is intentionally designed this way for security purposes and another reason why we recommend stubbing out our flow. 
 
 While Login.gov partner support channels have provided some support for automated testing in the past, as of 09/20/2023, will no longer be able to provide assistance in this area.
 

--- a/_pages/testing.md
+++ b/_pages/testing.md
@@ -42,7 +42,7 @@ Our sandbox environment is smaller than our production environment and it is sha
 
 **Similar to load testing, we strongly recommend stubbing out the portion of your tests that require signing a user into Login.gov or creating an account.** This is especially true for applications using identity verification, because we are frequently making updates to the code and the flow is likely to change and could unexpectedly break your tests. 
 
-If you are looking for reccomendations for automated testing, we do not have any specific advice. There are many different frameworks and automated testing suites available to choose from, and our partners usually pick based on their own unique needs. Regardless of which suite you choose, it should be noted that you cannot bypass the MFA portion of the flow. It is intentionally designed this way for security purposes and another reason why we reccomend stubbing out our flow. 
+If you are looking for recommendations for automated testing, we do not have any specific advice. There are many different frameworks and automated testing suites available to choose from, and our partners usually pick based on their own unique needs. Regardless of which suite you choose, it should be noted that you cannot bypass the MFA portion of the flow. It is intentionally designed this way for security purposes and another reason why we reccomend stubbing out our flow. 
 
 While Login.gov partner support channels have provided some support for automated testing in the past, as of 09/20/2023, will no longer be able to provide assistance in this area.
 

--- a/_pages/testing.md
+++ b/_pages/testing.md
@@ -36,7 +36,7 @@ Make sure you're using the corresponding private key in your application to sign
 
 ## Load Testing
 
-Our sandbox environment is smaller than our production environment and it is shared by many of our partners. It has not been configured for load testing and is likely to crash. **For these reasons, our recommendation is to mock out the Login.gov portion of your load tests.** We thoroughly load test our infrastructure and can provide data on our capabilities upon request.
+Our sandbox environment is smaller than our production environment and it is shared by many of our partners. It has not been configured for load testing. **For these reasons, our recommendation is to mock out the Login.gov portion of your load tests.** We thoroughly load test our infrastructure and can provide data on our capabilities upon request.
 
 ## Automated Testing
 

--- a/_pages/testing.md
+++ b/_pages/testing.md
@@ -44,7 +44,7 @@ Our sandbox environment is smaller than our production environment and it is sha
 
 If you are looking for reccomendations for automated testing, we do not have any specific advice. There are many different frameworks and automated testing suites available to choose from, and our partners usually pick based on their own unique needs. Regardless of which suite you choose, it should be noted that you cannot bypass the MFA portion of the flow. It is intentionally designed this way for security purposes and another reason why we reccomend stubbing out our flow. 
 
-While Login.gov partner support channels have provided some support for automated testing in the past, as of 09/20/2023,  will no longer be able to provide assistance in this area.
+While Login.gov partner support channels have provided some support for automated testing in the past, as of 09/20/2023, will no longer be able to provide assistance in this area.
 
 ## Testing identity proofing
 

--- a/_pages/testing.md
+++ b/_pages/testing.md
@@ -42,7 +42,7 @@ Our sandbox environment is smaller than our production environment and it is sha
 
 **Similar to load testing, we strongly recommend stubbing out the portion of your tests that require signing a user into Login.gov or creating an account.** This is especially true for applications using identity verification, because we are frequently making updates to the code and the flow is likely to change and could unexpectedly break your tests. 
 
-If you are looking for recommendations for automated testing, we do not have any specific advice. There are many different frameworks and automated testing suites available to choose from, and our partners usually pick based on their own unique needs. Regardless of which suite you choose, it should be noted that you cannot bypass the MFA portion of the flow. It is intentionally designed this way for security purposes and another reason why we reccomend stubbing out our flow. 
+If you are looking for recommendations for automated testing, we do not have any specific advice. There are many different frameworks and automated testing suites available to choose from, and our partners usually pick based on their own unique needs. Regardless of which suite you choose, it should be noted that you cannot bypass the MFA portion of the flow. It is intentionally designed this way for security purposes and another reason why we recommend stubbing out our flow. 
 
 While Login.gov partner support channels have provided some support for automated testing in the past, as of 09/20/2023, will no longer be able to provide assistance in this area.
 

--- a/_pages/testing.md
+++ b/_pages/testing.md
@@ -34,9 +34,17 @@ openssl req -nodes -x509 -days 365 -newkey rsa:2048 -keyout private.pem -out pub
 
 Make sure you're using the corresponding private key in your application to sign and/or validate requests and responses to/from Login.gov.
 
-## Automated/Load Testing
+## Load Testing
 
-Our sandbox environment is smaller than our production environment and it is shared by many of our partners. For this reason, please do not perform automated tests that exceed 1000 requests/minute. Our Partner Support Help Desk is not able to assist with setting up automated tests, but are happy to discuss options to meet your needs.
+Our sandbox environment is smaller than our production environment and it is shared by many of our partners. It has not been configured for load testing and is likely to crash. **For these reasons, our reccomendation is to mock out the Login.gov portion of your load tests.** We thoroughly load test our infrastructure and can provide data on our capabilities upon request.
+
+## Automated Testing
+
+**Similar to load testing, we strongly reccomend stubbing out the portion of your tests that require signing a user into Login.gov or creating an account.** This is especially true for applications using identity verification, because we are frequently making updates to the code and the flow is likely to change and could unexpectedly break your tests. 
+
+If you are looking for reccomendations for automated testing, we do not have any specific advice. There are many different frameworks and automated testing suites available to choose from, and our partners usually pick based on their own unique needs. Regardless of which suite you choose, it should be noted that you cannot bypass the MFA portion of the flow. It is intentionally designed this way for security purposes and another reason why we reccomend stubbing out our flow. 
+
+While Login.gov partner support channels have provided some support for automated testing in the past, as of 09/20/2023,  will no longer be able to provide assistance in this area.
 
 ## Testing identity proofing
 


### PR DESCRIPTION
For LG-10887: https://cm-jira.usa.gov/browse/LG-10887?filter=-1

break out automated testing/load testing into two sections for clarity 

explicitly state we do not support automated testing - reccommend stubbing it out