### PR TITLE
Document special first_name values to simulate proofing vendor errors

### DIFF
--- a/_pages/testing.md
+++ b/_pages/testing.md
@@ -107,7 +107,7 @@ Login.gov collects and verifies personal information during the proofing process
 
 To simulate a failure, enter a social security number that does not start with “900” or “666”, such as “123-45-6789”.
 
-You can simulate failure to contact a proofing vendor by entering a social security number of “000-00-0000”. See next section for more ways to simulate vendor errors.
+You can simulate failure to contact a proofing vendor by entering a social security number of “000-00-0000”. See ["proofing vendor errors"](#proofing-vendor-errors) for more ways to simulate vendor errors.
 
 ### Proofing vendor errors
 

--- a/_pages/testing.md
+++ b/_pages/testing.md
@@ -107,6 +107,23 @@ Login.gov collects and verifies personal information during the proofing process
 
 To simulate a failure, enter a social security number that does not start with “900” or “666”, such as “123-45-6789”.
 
+You can simulate failure to contact a proofing vendor by entering a social security number of “000-00-0000”. See next section for more ways to simulate vendor errors.
+
+### Proofing vendor errors
+
+To simulate issues with proofing vendor responses, create a YAML file that includes a specific `first_name` field, as specified below. Save the example YAML file below and edit the `first_name` field to give the result you want.
+
+|first_name| Result|
+|--------|--------|
+| Bad | unverified user |
+| Fail | failed to contact vendor |
+| Parse | parse error in vendor response |
+| Time | vendor timeout |
+
+To simulate failure to verify a zipcode, enter “00000” for the user's zipcode.
+
+Sample YAML file:
+{% include yaml_download.md filename="proofing_vendor_error.yml" %}
 
 ### Issuing source verification for ID documents
 

--- a/assets/yaml/proofing_vendor_error.yml
+++ b/assets/yaml/proofing_vendor_error.yml
@@ -1,0 +1,15 @@
+document:
+  type: license
+  first_name: Parse
+  last_name: Smith
+  middle_name: Q
+  address1: 1 Microsoft Way
+  address2: Apt 3
+  city: Bayside
+  state: WA
+  zipcode: '99237'
+  dob: 10/06/2000
+  phone: +1 206-555-1212
+  state_id_number: '123456789'
+  state_id_type: drivers_license
+  state_id_jurisdiction: 'WA'


### PR DESCRIPTION
While making identity-idp [PR 9250](https://github.com/18F/identity-idp/pull/9250), @theabrad suggested documenting the change, so we added documentation for all the special first names that simulate proofing errors.

Recommend not merging this until that PR is deployed on Tuesday.