### PR TITLE
Need to add custom css to add height-viewport in >tablet size

### DIFF
--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -36,3 +36,9 @@
 .usa-layout-docs__sidenav {
   top: 2rem;
 }
+
+@media (min-width: 880px) {
+  .tablet-lg\:height-viewport {
+    height: 100vh;
+  }
+}


### PR DESCRIPTION
### Relevant Ticket

[LG-9737](https://cm-jira.usa.gov/browse/LG-9737)

[Figma](https://www.figma.com/file/HHD28cToRlcOcqYcrFIm2o/Login.gov-Developer-Guide-(LG-9258%2C-LG-9244)?type=design&node-id=0-1&mode=design)

### Description of Changes

Adds `tablet-lg:height-viewport` [responsive variant](https://designsystem.digital.gov/utilities/height-and-width/#responsive-variants-2) to only apply the height being set to `100vh` only on tablet-lg and larger. This is necessary to not having extra spacing below the left nav on mobile, and to have it be sticky on larger screens.

