### PR TITLE
Add note about requesting SET configuration to be added to the outbound proxy

### DIFF
--- a/_pages/security-events.md
+++ b/_pages/security-events.md
@@ -223,8 +223,8 @@ To configure your application to receive notifications from Login.gov, supply Lo
 
 #### Production environment:
 
-- Open a Zendesk ticket to have your SET configuration added to our outbound proxy
-- The `push_notification_url` will be deployed as part of the application promotion process
+- The `push_notification_url` will be deployed as part of the application promotion process. Please specify in the
+promotion request that you are including a SET configuration so tht we know to add your URL to the outbound proxy.
 
 ### Supported Outgoing Events
 

--- a/_pages/security-events.md
+++ b/_pages/security-events.md
@@ -224,7 +224,7 @@ To configure your application to receive notifications from Login.gov, supply Lo
 #### Production environment:
 
 - The `push_notification_url` will be deployed as part of the application promotion process. Please specify in the
-promotion request that you are including a SET configuration so tht we know to add your URL to the outbound proxy.
+promotion request that you are including a SET configuration so that we know to add your URL to our outbound proxy allowlist.
 
 ### Supported Outgoing Events
 

--- a/_pages/security-events.md
+++ b/_pages/security-events.md
@@ -217,8 +217,14 @@ Content-Type: application/json
 
 To configure your application to receive notifications from Login.gov, supply Login.gov with a URL to POST to. The URL must be publicly accessible with HTTPS using a certificate signed by a trusted certificate authority.
 
-- In the agency integration environment, use the dashboard to supply a `push_notification_url` for your application
-- In production `push_notification_url` can be supplied as part of the application promotion process
+#### Agency integration environment:
+
+- Use the dashboard to supply a `push_notification_url` for your application
+
+#### Production environment:
+
+- Open a Zendesk ticket to have your SET configuration added to our outbound proxy
+- The `push_notification_url` will be deployed as part of the application promotion process
 
 ### Supported Outgoing Events
 


### PR DESCRIPTION
When partners add a SET push_notification_url, they need to be added to our outbound proxy to work. This request step should be documented somewhere, otherwise it def won't happen.