### PR TITLE
Add word-wrap to stop having scroll in the X axis on mobile

### DIFF
--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -7,6 +7,10 @@
 );
 @forward "uswds";
 
+main.usa-layout-docs {
+  word-wrap: break-word;
+}
+
 .usa-prose {
   figure {
     max-width: 64ex;


### PR DESCRIPTION
Add `word-wrap: break-word;` to `main.usa-layout-docs` to break long URLs that extend beyond the width of the device to stop the page being scrollable on the X axis.

Before:
<img width="399" alt="image" src="https://github.com/18F/identity-dev-docs/assets/2308626/b03a45fb-9dc9-4606-9de2-94adeac95f6f">

After:
<img width="396" alt="image" src="https://github.com/18F/identity-dev-docs/assets/2308626/f992aa44-2346-41d3-a800-bb46e7d98617">
