### PR TITLE
Add return to top alt text for mobile

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -133,7 +133,7 @@
           </div>
           <div class="grid-col flex-auto">
             <a href="#" class="usa-button usa-button--outline return-to-top-button mobile:display-none desktop:display-block position-fixed bottom-205 right-105 z-500">Return to top</a>
-            <a href="#" class="usa-button usa-button--outline return-to-top-button desktop:display-none position-fixed bottom-205 right-105 width-5 height-5 text-middle radius-pill z-500 shadow-2"><img class="display-inline maxw-3 width-3 height-3 position-absolute left-1 top-1" src="{{ site.baseurl }}/assets/img/material-icons/expand_less.svg"/></a>
+            <a href="#" class="usa-button usa-button--outline return-to-top-button desktop:display-none position-fixed bottom-205 right-105 width-5 height-5 text-middle radius-pill z-500 shadow-2"><img alt="Return to top" class="display-inline maxw-3 width-3 height-3 position-absolute left-1 top-1" src="{{ site.baseurl }}/assets/img/material-icons/expand_less.svg"/></a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Missed the accessibility AC for [LG-9739](https://cm-jira.usa.gov/browse/LG-9739). This adds alt-text for the mobile return to top button for accessibility.