### PR TITLE
add openid scope requirement

### DIFF
--- a/_pages/oidc.md
+++ b/_pages/oidc.md
@@ -155,8 +155,11 @@ https://idp.int.identitysandbox.gov/openid_connect/authorize?
   The URI Login.gov will redirect to after a successful authorization.
 
 * **scope**
-  A space-separated string of the scopes being requested. The authorization page will display the list of attributes being requested from the user. Applications should aim to request the fewest [user attributes]({{ site.baseurl }}/attributes/) and smallest scope needed. Possible values are:
-   - `openid`
+  A space-separated string of the scopes being requested. The authorization page will display the list of attributes being requested from the user. Applications should aim to request the fewest [user attributes]({{ site.baseurl }}/attributes/) and smallest scope needed.
+
+  **The [OIDC spec](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequestValidation) requires that the scope parameter contains `openid` as a value.**
+
+  Possible attributes are:
    - `address`
    - `email`
    - `all_emails`


### PR DESCRIPTION
Our current documentation does not note that openid is required to be passed through the scope attribute