### PR TITLE
LG-11411 make OIDC certificates page

### DIFF
--- a/_includes/snippets/oidc/certificates.md
+++ b/_includes/snippets/oidc/certificates.md
@@ -1,0 +1,8 @@
+{% capture ssl %}
+```
+openssl req -nodes -x509 -days 365 -newkey rsa:2048 -keyout private.pem -out public.crt
+```
+{% endcapture %}
+<div markdown="1" data-example="ssl" class="markdown">
+{{ ssl | markdownify }}
+</div>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -138,7 +138,7 @@
 
     {{ content }}
 
-      <footer class="usa-footer usa-footer--slim" role="contentinfo" aria-label="GSA footer">
+      <footer class="usa-footer usa-footer--slim usa-footer--slim__z-index" role="contentinfo" aria-label="GSA footer">
         <div class="usa-footer__secondary-section">
           <div class="grid-container">
             <div class="usa-footer__logo grid-row grid-gap-2">

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -138,7 +138,7 @@
 
     {{ content }}
 
-      <footer class="usa-footer usa-footer--slim usa-footer--slim__z-index" role="contentinfo" aria-label="GSA footer">
+      <footer class="usa-footer usa-footer--slim position-relative z-100" role="contentinfo" aria-label="GSA footer">
         <div class="usa-footer__secondary-section">
           <div class="grid-container">
             <div class="usa-footer__logo grid-row grid-gap-2">

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -21,7 +21,7 @@ layout: base
           </aside>
         </div>
 
-        <div class="usa-layout-docs__main desktop:grid-col-10 usa-prose">
+        <div class="usa-layout-docs__main desktop:grid-col-10 usa-prose z-0">
 
           {% if site.temporary_alert %}
             {% include alert.html content=site.temporary_alert %}

--- a/_pages/oidc/certificates.md
+++ b/_pages/oidc/certificates.md
@@ -1,0 +1,43 @@
+---
+title: OpenID Connect
+lead: >
+    [OpenID Connect](http://openid.net){:class="usa-link--external"} is a simple identity layer built on top of the OAuth 2.0 protocol. Login.gov supports [version 1.0](http://openid.net/specs/openid-connect-core-1_0.html){:class="usa-link--external"} of the specification and conforms to the [iGov Profile](https://openid.net/wg/igov){:class="usa-link--external"}.
+sidenav:
+  - text: Getting started
+    href: "oidc/getting-started/"
+  - text: Authorization
+    href: "oidc/authorization/"
+  - text: Token
+    href: "oidc/token/"
+  - text: User info
+    href: "oidc/user-info/"
+  - text: Certificates
+    href: "oidc/certificates/"
+  - text: Logout
+    href: "oidc/#logout"
+  - text: Example application
+    href: "oidc/#example-application"
+
+---
+
+{% capture content %}
+## Certificates
+
+Login.gov's public key, used to verify signed JWTs (such as the `id_token`), is available in [JWK](https://tools.ietf.org/html/rfc7517){:class="usa-link--external"} format at the `/api/openid_connect/certs` endpoint. 
+
+This public key is rotated periodically (on at least an annual basis). It is important to assume the `/api/openid_connect/certs` endpoint could contain multiple JWKs when rotating application signing keys. Be sure to use the JWK endpoint dynamically through [auto-discovery]({{ site.baseurl }}/oidc/getting-started/#auto-discovery) rather than hardcoding the public key. This ensures that your application will not require manual intervention when the Login.gov public key is rotated.
+{% endcapture %}
+
+<div class="grid-row grid-gap">
+  <div class="desktop:grid-col-8 mobile:grid-col-full">
+    {{ content | markdownify }}
+     <a href="{{ site.baseurl }}/oidc/#logout" class="usa-link margin-top-4 mobile:display-none desktop:display-block">Next step: Logout</a>
+  </div>
+    <div class="usa-layout-docs__main code-snippet-column desktop:grid-col-4">
+      <section id="pkce" class="code-snippet-section">
+        <span class="code-button code-button__selected margin-left-2">OpenSSL Command</span>
+          {% include snippets/oidc/certificates.md %}
+      </section>
+    </div>
+      <a href="{{ site.baseurl }}/oidc/#logout" class="usa-link mobile:display-block desktop:display-none margin-top-2">Next step: Logout</a>
+</div>

--- a/_pages/oidc/token.md
+++ b/_pages/oidc/token.md
@@ -4,7 +4,7 @@ lead: >
     [OpenID Connect](http://openid.net){:class="usa-link--external"} is a simple identity layer built on top of the OAuth 2.0 protocol. Login.gov supports [version 1.0](http://openid.net/specs/openid-connect-core-1_0.html){:class="usa-link--external"} of the specification and conforms to the [iGov Profile](https://openid.net/wg/igov){:class="usa-link--external"}.
 sidenav:
   - text: Getting started
-    href: "oidc/#getting-started"
+    href: "oidc/getting-started/"
   - text: Authorization
     href: "oidc/authorization/"
   - text: Token

--- a/_pages/oidc/user-info.md
+++ b/_pages/oidc/user-info.md
@@ -4,7 +4,7 @@ lead: >
     [OpenID Connect](http://openid.net){:class="usa-link--external"} is a simple identity layer built on top of the OAuth 2.0 protocol. Login.gov supports [version 1.0](http://openid.net/specs/openid-connect-core-1_0.html){:class="usa-link--external"} of the specification and conforms to the [iGov Profile](https://openid.net/wg/igov){:class="usa-link--external"}.
 sidenav:
   - text: Getting started
-    href: "oidc/#getting-started"
+    href: "oidc/getting-started/"
   - text: Authorization
     href: "oidc/authorization/"
   - text: Token

--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -162,11 +162,6 @@ button.code-button:hover {
   padding-top: 1rem;
 }
 
-.usa-footer--slim.usa-footer--slim__z-index {
-  z-index: 1;
-  position:relative;
-}
-
 @media (min-width: 1024px) {
   .code-snippet-column {
     background-color: transparent;

--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -162,6 +162,11 @@ button.code-button:hover {
   padding-top: 1rem;
 }
 
+.usa-footer--slim.usa-footer--slim__z-index {
+  z-index: 1;
+  position:relative;
+}
+
 @media (min-width: 1024px) {
   .code-snippet-column {
     background-color: transparent;
@@ -174,11 +179,11 @@ button.code-button:hover {
     right: -15px;
     width: 100%;
     display: block;
-    z-index: 0;
+    z-index: -1;
     position: absolute;
     background-color: #f0f0f0;
     top: 0;
     margin-top: -4rem;
-    bottom: -11rem;
+    bottom: -15rem;
   }
 }


### PR DESCRIPTION
https://cm-jira.usa.gov/browse/LG-11411

The next page in OIDC developer guide rework/redesign: Certificate Page

Please use this Figma doc to compare for design accuracy:
https://www.figma.com/file/3KSAr0qfDv8BXFIHyFEudZ/Login.gov-OIDC%2C-SAML%2C-and-UX-guides-(LG-10262%2C-LG-10514)?type=design&node-id=104-4347&mode=design&t=YDYdtdA55wzFHwf2-0

Note: had to tweak the CSS a bit for the sidebar because it wasn't stretching to the bottom on this page 