### PR TITLE
LG- 11436: Bringing back sidenav on testing page

### DIFF
--- a/_pages/oidc/getting-started.md
+++ b/_pages/oidc/getting-started.md
@@ -4,6 +4,7 @@ lead: >
    [OpenID Connect](http://openid.net){:class="usa-link--external"} is a simple identity layer built on top of the OAuth 2.0 protocol. Login.gov supports [version 1.0](http://openid.net/specs/openid-connect-core-1_0.html){:class="usa-link--external"} of the specification and conforms to the [iGov Profile](https://openid.net/wg/igov){:class="usa-link--external"}.
 redirect_from:
   - /openid-connect/
+  - /oidc/
 sidenav:
   - text: Getting started
     href: "oidc/getting-started/"

--- a/_pages/testing.md
+++ b/_pages/testing.md
@@ -5,6 +5,22 @@ lead: >
 redirect_from:
   - /registering-your-sp/
   - /register/
+sidenav:
+  - text: About the Login.gov sandbox
+    href: "#about-the-logingov-sandbox"
+  - text: Getting access to the Login.gov sandbox
+    href: "#getting-access-to-the-logingov-sandbox"
+  - text: Using the sandbox
+    href: "#using-the-sandbox"
+  - text: If you lost access to a sandbox team
+    href: "#if-you-lost-access-to-a-sandbox-team"
+  - text: Load Testing
+    href: "#load-testing"
+  - text: Automated Testing
+    href: "#automated-testing"
+  - text: Testing identity proofing
+    href: "#testing-identity-proofing"
+
 ---
 
 ## About the Login.gov sandbox


### PR DESCRIPTION
LG-11436: https://cm-jira.usa.gov/browse/LG-11436

It was brought to our attention that the Testing page in the dev docs is missing the side nav which makes navigating the page more difficult

Also in light of the new OIDC guide I realized I should add a redirect so people who have the old url to the oidc guide saved will get redirected to the new page 