### PR TITLE
LG-11486 Add oidc token errors

### DIFF
--- a/_data/errors.yml
+++ b/_data/errors.yml
@@ -120,14 +120,14 @@ oidc:
         - Update your logout request to utilize the client_id attribute.
         More information about the logout request parameters can be found here: [https://developers.login.gov/oidc/logout/#logout-request](https://developers.login.gov/oidc/logout/#logout-request){:target="_blank"}.
   token:
-    - title: is expired
+    - title: Code is expired
       id: token-expired
       accordion-id: token_expired
       content: |
         ##### Why it's happening
-        In the authentication response, a `code` value is returned that is then used in the `token` endpoint request. The code is intended to be used immediately (within 15 minutes) after it has been generated. This error may mean that the user paused for too long during the authentication attempt.
+        In the authentication response, a `code` value is returned that is then used in the `token` endpoint request. "The code is intended to be used within 15 minutes immediately after it is generated. This error may mean that the user paused for too long during the authentication attempt.
         ##### What to do:
-        - Attempt another authentication attempt without pauses.
+        - Try another authentication attempt without pausing.
     - title: Invalid audience claim
       id: invalid-aud-claim
       accordion-id: invalid_aud_claim
@@ -183,6 +183,7 @@ oidc:
         The `iat` value in the `client_assertion` JWT is the time at which the JWT was issued. It takes the format of an integer timestamp representing the number of seconds since the Unix Epoch. This error means that it is:
         - Not an integer or floating point Unix timestamp, OR
         - It is not an integer/timestamp that is in the past.
+
         ##### What to do:
         - Ensure your application is correctly generating the `iat` value in the `client_assertion` JWT.
         - If you are correctly creating the value, your server may be experiencing server time drift. Time drift can happen slowly over time. You may need to update or reset your server's clock. We recommend syncing your system with a timeserver like [https://time.gov/](https://time.gov/){:target="_blank"}.

--- a/_data/errors.yml
+++ b/_data/errors.yml
@@ -149,6 +149,7 @@ oidc:
         ##### What to do:
         If your integration is PKCE:
         - Ensure you are sending the `code_verifier` attribute as part of your token request. The value of this attribute is the original value of the `code_challenge` parameter sent in your original authentication request.
+
         If your integration is private_key_jwt:
         - Ensure you are sending `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer` as part of your token request.
 

--- a/_data/errors.yml
+++ b/_data/errors.yml
@@ -136,8 +136,8 @@ oidc:
         The `aud` value in the `client_assertion` JWT is not correct.
         ##### What to do:
         - Check the `aud` key in the `client_assertion` JWT that is being sent in your `token` request.
-        Integration environment value: https://idp.int.identitysandbox.gov/api/openid_connect/token
-        Production environment value: https://secure.login.gov/api/openid_connect/token
+        Integration environment value: `https://idp.int.identitysandbox.gov/api/openid_connect/token`
+        Production environment value: `https://secure.login.gov/api/openid_connect/token`
 
         More information about the client assertion values can be found here: [https://developers.login.gov/oidc/token/#client_assertion](https://developers.login.gov/oidc/token/#client_assertion){:target="_blank"}.
     - title: Client must authenticate via PKCE or private_key_jwt, missing either code_challenge or client_assertion
@@ -180,7 +180,7 @@ oidc:
       accordion-id: invalid_iat
       content: |
         ##### Why it's happening
-        The `iat` value in the `client_assertion` JWT is the time at which the JWT was issued. It takes the format of an integer timestamp representing the number of seconds since the Unix Epoch. This error means that it is:
+        The [`iat`](https://developers.login.gov/oidc/token/#iat-number) value in the `client_assertion` JWT is the time at which the JWT was issued. It takes the format of an integer timestamp representing the number of seconds since the Unix Epoch. This error means that it is:
         - Not an integer or floating point Unix timestamp, OR
         - It is not an integer/timestamp that is in the past.
 

--- a/_data/errors.yml
+++ b/_data/errors.yml
@@ -20,7 +20,7 @@ oidc:
         Check the `acr_values` parameter in your authentication request and ensure that you are passing either:
         - `http://idmanagement.gov/ns/assurance/ial/1` for Authentication Only applications, OR;
         - `http://idmanagement.gov/ns/assurance/ial/2` for Identity-Verification Permitted applications.
-        Learn more about IAL values here: [https://developers.login.gov/oidc/#ial-values](https://developers.login.gov/oidc/#ial-values){:target="_blank"}
+        Learn more about IAL Service Level values here: [https://developers.login.gov/oidc/authorization/#service_level]https://developers.login.gov/oidc/authorization/#service_level){:target="_blank"}
     - title: The acr_values are not authorized
       id: oidc-missing-acr-values
       accordion-id: missing_acr
@@ -41,8 +41,8 @@ oidc:
         No AAL levels are present in the acr_values parameter of the authentication request.
         ##### What to do:
         - Check the `acr_values` parameter in your authentication request.
-        - Ensure that you are passing in the appropriate IAL value as well as any AAL values you might want for your application.
-        More information about the `acr_values` parameter can be found here: [https://developers.login.gov/oidc/#request-parameters](https://developers.login.gov/oidc/#request-parameters){:target="_blank"}
+        - Ensure that you are passing in the appropriate IAL Service Level value as well as any Authentication Assurance (AAL) values you might want for your application.
+        More information about the `acr_values` parameter can be found here: [https://developers.login.gov/oidc/authorization/#acr_values](https://developers.login.gov/oidc/authorization/#acr_values){:target="_blank"}
     - title: No valid scope values found
       id: oidc-no-scope
       accordion-id: no_scope
@@ -62,7 +62,7 @@ oidc:
         ##### What to do:
         - Check the `prompt` parameter in your authentication request.
         - Ensure you are passing `select_account` as the value.
-        More information about the `prompt` request parameter can be found here: [https://developers.login.gov/oidc/](https://developers.login.gov/oidc/#request-parameters){:target="_blank"}
+        More information about the `prompt` request parameter can be found here: [https://developers.login.gov/oidc/authorization/#prompt](https://developers.login.gov/oidc/authorization/#prompt){:target="_blank"}
     - title: redirect_uri is invalid
       id: oidc-invalid-redirect
       accordion-id: invalid_redirect
@@ -118,4 +118,78 @@ oidc:
         We are no longer supporting the id_token_hint attribute as a method of logging out.
         ##### What to do:
         - Update your logout request to utilize the client_id attribute.
-        More information about the logout request parameters can be found here: [https://developers.login.gov/oidc/#logout-request](https://developers.login.gov/oidc/#logout-request){:target="_blank"}.
+        More information about the logout request parameters can be found here: [https://developers.login.gov/oidc/logout/#logout-request](https://developers.login.gov/oidc/logout/#logout-request){:target="_blank"}.
+  token:
+    - title: is expired
+      id: token-expired
+      accordion-id: token_expired
+      content: |
+        ##### Why it's happening
+        In the authentication response, a `code` value is returned that is then used in the `token` endpoint request. The code is intended to be used immediately (within 15 minutes) after it has been generated. This error may mean that the user paused for too long during the authentication attempt.
+        ##### What to do:
+        - Attempt another authentication attempt without pauses.
+    - title: Invalid audience claim
+      id: invalid-aud-claim
+      accordion-id: invalid_aud_claim
+      content: |
+        ##### Why it's happening
+        The `aud` value in the `client_assertion` JWT is not correct.
+        ##### What to do:
+        - Check the `aud` key in the `client_assertion` JWT that is being sent in your `token` request.
+        Integration environment value: https://idp.int.identitysandbox.gov/api/openid_connect/token
+        Production environment value: https://secure.login.gov/api/openid_connect/token
+
+        More information about the client assertion values can be found here: [https://developers.login.gov/oidc/token/#client_assertion](https://developers.login.gov/oidc/token/#client_assertion){:target="_blank"}.
+    - title: Client must authenticate via PKCE or private_key_jwt, missing either code_challenge or client_assertion
+      id: pkce-or-private-key
+      accordion-id: pkce_or_private_key
+      content: |
+        ##### Why it's happening
+        OpenID Connect authentications must use either a PKCE or a private_key_jwt authentication menthod. Both methods require specific values to be sent in `token` endpoint request.
+        ##### What to do:
+        If your integration is PKCE:
+        - Ensure you are sending the `code_verifier` attribute as part of your token request. The value of this attribute is the original value of the `code_challenge` parameter sent in your original authentication request.
+        If your integration is private_key_jwt:
+        - Ensure you are sending `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer` as part of your token request.
+
+        More information about token request values can be found here: [https://developers.login.gov/oidc/token/#request-parameters](https://developers.login.gov/oidc/token/#request-parameters){:target="_blank"}.
+    - title: Code is invalid because doesn’t match any user. Please see our documentation at https://developers.login.gov/oidc/#token
+      id: invalid-code
+      accordion-id: invalid_code
+      content: |
+        ##### Why it's happening
+        The `code` value being passed in the token request does not match any users. This typically happens when the code value is being reused in multiple token requests, or because the `code` value is not being passed in the token request.
+        ##### What to do:
+        - Ensure you are passing a `code` parameter in your token request.
+        - Ensure there is no possibility of the `code` value in the token request being sent multiple times.
+
+        Reasons can include:
+        - Browser is forcing an unexpected refresh
+        - User refreshes browser
+    - title: code_verifier did not match code_challenge
+      id: invalid-code-verifier
+      accordion-id: invalid_code_verifier
+      content: |
+        ##### Why it's happening
+        If you are using the PKCE protocol, the `code_verifier` value being passed in the **token** request does not match the decoded `code_challenge` value passed in the **authentication** request.
+        ##### What to do:
+        - Ensure that the `code_challenge` parameter is a URL-safe Base64 encoding of the SHA256 digest of the `code_verifier` parameter.
+    - title: iat must be an integer or floating point Unix timestamp representing a time in the past
+      id: invalid-iat
+      accordion-id: invalid_iat
+      content: |
+        ##### Why it's happening
+        The `iat` value in the `client_assertion` JWT is the time at which the JWT was issued. It takes the format of an integer timestamp representing the number of seconds since the Unix Epoch. This error means that it is:
+        - Not an integer or floating point Unix timestamp, OR
+        - It is not an integer/timestamp that is in the past.
+        ##### What to do:
+        - Ensure your application is correctly generating the `iat` value in the `client_assertion` JWT.
+        - If you are correctly creating the value, your server may be experiencing server time drift. Time drift can happen slowly over time. You may need to update or reset your server's clock. We recommend syncing your system with a timeserver like [https://time.gov/](https://time.gov/){:target="_blank"}.
+    - title: Could not validate assertion against any registered public keys
+      id: invalid-token-signature
+      accordion-id: invalid_token_signature
+      content: |
+        ##### Why it's happening
+        There is no registered certificate that matches the signature of the `client_assertion` JWT that is being passed as part of the token. request.
+        ##### What to do:
+        - Ensure that the public certificate that matches the private key used to sign the JWT is registered in your application's configuration in the [Partner Dashboard](https://dashboard.int.identitysandbox.gov/){:target="_blank"}.

--- a/_includes/support/oidc.html
+++ b/_includes/support/oidc.html
@@ -12,4 +12,10 @@
       {% include accordion.html content=error.content accordion_id=error.accordion-id  title=error.title id=error.id %}
     {% endfor %}
   </div>
+  <h4>Token</h4>
+  <div class="usa-accordion usa-accordion--bordered" aria-multiselectable="true">
+    {% for error in site.data.errors.oidc.token %}
+      {% include accordion.html content=error.content accordion_id=error.accordion-id  title=error.title id=error.id %}
+    {% endfor %}
+  </div>
 </div>

--- a/_pages/oidc/authorization.md
+++ b/_pages/oidc/authorization.md
@@ -196,6 +196,14 @@ In an **unsuccessful authorization**, the URI will contain the parameters `error
         </div>
       </div>
     </div>
+     <div class="grid-row dev-doc-row">
+      <div class="grid-col-5">
+        <h4 class="parameters clearfix">prompt</h4>
+      </div>
+      <div class="grid-col-7">
+          This must be <code class="language-plaintext highlighter-rouge">select_account</code>
+      </div>
+    </div>
     <div class="grid-row dev-doc-row">
       <div class="grid-col-5">
         <h4 class="parameters clearfix">response_type</h4>

--- a/_pages/oidc/token.md
+++ b/_pages/oidc/token.md
@@ -70,7 +70,7 @@ A [JWT](https://jwt.io/){:class="usa-link--external"} signed with the client’s
           <h4 class="parameters clearfix">code</h4>
         </div>
         <div class="grid-col-7 padding-bottom-2">
-            The authorization code returned by the <a class="usa-link" href="{{ site.baseurl }}/oidc/authorization/">authorization response</a>.
+            The authorization code returned by the <a class="usa-link" href="{{ site.baseurl }}/oidc/authorization/#code">authorization response</a>.
         </div>
       </div>
     </div>


### PR DESCRIPTION
https://cm-jira.usa.gov/browse/LG-11486

This change:
- Adds oidc token errors in the error dictionart
- Updates relevant error urls to match the new OIDC view
- Updates a couple other urls that I discovered could be more specific