### PR TITLE
Change indentation to force markdown to parse

### DIFF
--- a/_pages/support.md
+++ b/_pages/support.md
@@ -552,8 +552,8 @@ There are some cases where our team is unable to help, typically either for secu
     </button>
   </h3>
   <div id="user-support" class="usa-accordion__container">
-    <div class="usa-accordion__content" markdown="1">
-      If you receive a complaint from a user having trouble logging in or managing their account, it is best to direct them to [submit a help ticket to user support](https://www.login.gov/contact/).
-    </div>
+<div class="usa-accordion__content" markdown="1">
+If you receive a complaint from a user having trouble logging in or managing their account, it is best to direct them to [submit a help ticket to user support](https://www.login.gov/contact/).
+</div>
   </div>
 </div>


### PR DESCRIPTION
The indentation of markdown divs have to be all the way at the start of the line for markdown to render properly.

https://federalist-14ccf384-8bd5-4e30-aa95-a5fe5894e3c1.sites.pages.cloud.gov/preview/18f/identity-dev-docs/jcurcio/lg-11100-add-technical-support-guidance/support/

<img width="1162" alt="image" src="https://github.com/18F/identity-dev-docs/assets/2308626/8c9559b6-aa0b-4da9-94c2-3b0a44547f0f">
