### PR TITLE
Add userinfo errors

### DIFF
--- a/_data/errors.yml
+++ b/_data/errors.yml
@@ -125,7 +125,7 @@ oidc:
       accordion-id: token_expired
       content: |
         ##### Why it's happening
-        In the authentication response, a `code` value is returned that is then used in the `token` endpoint request. "The code is intended to be used within 15 minutes immediately after it is generated. This error may mean that the user paused for too long during the authentication attempt.
+        In the authentication response, a `code` value is returned that is then used in the `token` endpoint request. The code is intended to be used within 15 minutes immediately after it is generated. This error may mean that the user paused for too long during the authentication attempt.
         ##### What to do:
         - Try another authentication attempt without pausing.
     - title: Invalid audience claim

--- a/_data/errors.yml
+++ b/_data/errors.yml
@@ -195,3 +195,31 @@ oidc:
         There is no registered certificate that matches the signature of the `client_assertion` JWT that is being passed as part of the token. request.
         ##### What to do:
         - Ensure that the public certificate that matches the private key used to sign the JWT is registered in your application's configuration in the [Partner Dashboard](https://dashboard.int.identitysandbox.gov/){:target="_blank"}.
+  userinfo:
+    - title: Malformed Authorization header
+      id: malformed-auth-header
+      accordion-id: malformed_auth_header
+      content: |
+        ##### Why it's happening
+        The `userinfo` endpoint requires an Authorization Header that includes a Bearer token. The Bearer token value is the `access_token` value from the `token` endpoint response.
+        ##### What to do:
+        - Ensure you are sending an [Authorization header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization){:target="_blank"} in your request to the `userinfo` endpoint.
+        - Ensure the value of the header is `Bearer` followed by the [`access_token`](https://developers.login.gov/oidc/token/#access_token-string){:target="_blank"} that was returned by the `token` endpoint.
+    - title: No Authorization header provided
+      id: no-auth-header
+      accordion-id: no_auth_header
+      content: |
+        ##### Why it's happening
+        The `userinfo` endpoint requires an Authorization Header.
+        ##### What to do:
+        - Ensure you are sending an [Authorization header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization){:target="_blank"} in your request to the `userinfo` endpoint.
+        - Ensure the value of the header is `Bearer` followed by the [`access_token`](https://developers.login.gov/oidc/token/#access_token-string){:target="_blank"} that was returned by the `token` endpoint.
+    - title: Could not find authorization for the contents of the provided access_token or it may have expired
+      id: auth-header-contents-not-found
+      accordion-id: auth_header_contents_not_found
+      content: |
+        ##### Why it's happening
+        The Bearer token value that is being passed as part of the userinfo endpoint request does not match a live user session. The value may be wrong, or there may have been a long pause during the authentication attempt.
+        ##### What to do:
+        - Ensure the Authorization header value is `Bearer` followed by the [`access_token`](https://developers.login.gov/oidc/token/#access_token-string){:target="_blank"} that was returned by the `token` endpoint.
+         - Try another authentication attempt without pausing.

--- a/_data/errors.yml
+++ b/_data/errors.yml
@@ -125,7 +125,7 @@ oidc:
       accordion-id: token_expired
       content: |
         ##### Why it's happening
-        In the authentication response, a `code` value is returned that is then used in the `token` endpoint request. The code is intended to be used within 15 minutes immediately after it is generated. This error may mean that the user paused for too long during the authentication attempt.
+        In the authentication response, a `code` value is returned that is then used in the `token` endpoint request. The code must be used within 15 minutes after it is generated. This error may mean that the user paused for too long during the authentication attempt.
         ##### What to do:
         - Try another authentication attempt without pausing.
     - title: Invalid audience claim
@@ -186,7 +186,7 @@ oidc:
 
         ##### What to do:
         - Ensure your application is correctly generating the `iat` value in the `client_assertion` JWT.
-        - If you are correctly creating the value, your server may be experiencing server time drift. Time drift can happen slowly over time. You may need to update or reset your server's clock. We recommend syncing your system with a timeserver like [https://time.gov/](https://time.gov/){:target="_blank"}.
+        - If you are correctly creating the value, your server may be experiencing server time drift. Time drift can happen slowly over time. You may need to update or reset your server's clock. We recommend syncing your system with a timeserver like [https://time.gov/](https://time.gov/){:target="_blank" .usa-link--external}.
     - title: Could not validate assertion against any registered public keys
       id: invalid-token-signature
       accordion-id: invalid_token_signature
@@ -203,7 +203,7 @@ oidc:
         ##### Why it's happening
         The `userinfo` endpoint requires an Authorization Header that includes a Bearer token. The Bearer token value is the `access_token` value from the `token` endpoint response.
         ##### What to do:
-        - Ensure you are sending an [Authorization header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization){:target="_blank"} in your request to the `userinfo` endpoint.
+        - Ensure you are sending an [Authorization header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization){:target="_blank" .usa-link--external} in your request to the `userinfo` endpoint.
         - Ensure the value of the header is `Bearer` followed by the [`access_token`](https://developers.login.gov/oidc/token/#access_token-string){:target="_blank"} that was returned by the `token` endpoint.
     - title: No Authorization header provided
       id: no-auth-header
@@ -212,7 +212,7 @@ oidc:
         ##### Why it's happening
         The `userinfo` endpoint requires an Authorization Header.
         ##### What to do:
-        - Ensure you are sending an [Authorization header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization){:target="_blank"} in your request to the `userinfo` endpoint.
+        - Ensure you are sending an [Authorization header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization){:target="_blank" .usa-link--external} in your request to the `userinfo` endpoint.
         - Ensure the value of the header is `Bearer` followed by the [`access_token`](https://developers.login.gov/oidc/token/#access_token-string){:target="_blank"} that was returned by the `token` endpoint.
     - title: Could not find authorization for the contents of the provided access_token or it may have expired
       id: auth-header-contents-not-found
@@ -221,5 +221,5 @@ oidc:
         ##### Why it's happening
         The Bearer token value that is being passed as part of the userinfo endpoint request does not match a live user session. The value may be wrong, or there may have been a long pause during the authentication attempt.
         ##### What to do:
-        - Ensure the Authorization header value is `Bearer` followed by the [`access_token`](https://developers.login.gov/oidc/token/#access_token-string){:target="_blank"} that was returned by the `token` endpoint.
+        - Ensure the Authorization header value is `Bearer` followed by the [`access_token`](https://developers.login.gov/oidc/token/#access_token-string){:target="_blank" .usa-link--external} that was returned by the `token` endpoint.
          - Try another authentication attempt without pausing.

--- a/_includes/support/oidc.html
+++ b/_includes/support/oidc.html
@@ -18,4 +18,10 @@
       {% include accordion.html content=error.content accordion_id=error.accordion-id  title=error.title id=error.id %}
     {% endfor %}
   </div>
+  <h4>Userinfo endpoint</h4>
+  <div class="usa-accordion usa-accordion--bordered" aria-multiselectable="true">
+    {% for error in site.data.errors.oidc.userinfo %}
+      {% include accordion.html content=error.content accordion_id=error.accordion-id  title=error.title id=error.id %}
+    {% endfor %}
+  </div>
 </div>


### PR DESCRIPTION
Jira ticket:
https://cm-jira.usa.gov/browse/LG-11487

This PR adds the userinfo errors to the error dictionary.
The errors can be found here: https://github.com/18F/identity-idp/blob/main/config/locales/openid_connect/en.yml#L47-L50