### PR TITLE
LG-11829 Add OSC analytics tracking tag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,9 @@ url: https://developers.login.gov
 # temporary_alert: "The Login.gov sandbox (<b>not production</b>) will be unavailable from <b>5-6p ET on Tuesday, January 31st, 2023</b> for maintenance."
 temporary_alert: false
 
+# GSA Office of Strategic Communication (OSC) Google Analytics
+osc_analytics_ga_measurement_id: null
+
 plugins:
   - jekyll-redirect-from
   - jekyll-sitemap

--- a/_includes/osc_analytics.html
+++ b/_includes/osc_analytics.html
@@ -1,0 +1,8 @@
+<!-- Analytics for GSA's Office of Strategic Communication (OSC) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.osc_analytics_ga_measurement_id }}"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag() { dataLayer.push(arguments); }
+gtag('js', new Date());
+gtag('config', '{{ site.osc_analytics_ga_measurement_id }}');
+</script>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -173,5 +173,6 @@
 
     {% include dap.html %}
     {% include google_analytics.html %}
+    {% include osc_analytics.html %}
   </body>
 </html>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -2,6 +2,9 @@
 
 <html lang="en">
   <head>
+    {% include google_analytics.html %}
+    {% include osc_analytics.html %}
+    {% include dap.html %}
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
@@ -158,7 +161,7 @@
           </div>
         </div>
       </footer>
-  
+
     <script src="{{ site.baseurl }}/assets/js/toggle_view.js"></script>
     <script src="{{ site.baseurl }}/assets/js/main.js"></script>
     <script src="{{ site.baseurl }}/assets/js/anchor.js"></script>
@@ -170,9 +173,5 @@
         '#main-content h4:not(.usa-accordion__heading)'
       ].join(', '));
     </script>
-
-    {% include dap.html %}
-    {% include google_analytics.html %}
-    {% include osc_analytics.html %}
   </body>
 </html>

--- a/spec/page.md_spec.rb
+++ b/spec/page.md_spec.rb
@@ -1,19 +1,33 @@
 require 'spec_helper'
 
-Dir.glob('_site/**/*.html') do |page|
-  RSpec.describe page do
-    let(:doc) { Nokogiri::HTML(File.new(page.to_s)) }
+def redirect_page?(path)
+  File.read(path).include?('<meta http-equiv="refresh"')
+end
 
-    it 'does not have broken Markdown links' do
-      expect(doc.to_s).to_not include(')]')
-    end
+RSpec.describe 'all pages' do
+  files = Dir.glob('_site/**/*.html')
+  files.reject! {|path| redirect_page?(path) }
+  files.each do |page|
+    describe page do
+      let(:doc) { Nokogiri::HTML(File.new(page.to_s)) }
 
-    it 'links to valid headings' do
-      expect(doc).to link_to_valid_headers
-    end
+      it 'does not have broken Markdown links' do
+        expect(doc.to_s).to_not include(')]')
+      end
 
-    it 'links to valid internal pages' do
-      expect(doc).to link_to_valid_internal_pages
+      it 'links to valid headings' do
+        expect(doc).to link_to_valid_headers
+      end
+
+      it 'links to valid internal pages' do
+        expect(doc).to link_to_valid_internal_pages
+      end
+
+      it 'includes analytics tags' do
+        expect(doc.to_s).to include('https://www.google-analytics.com/analytics.js')
+        expect(doc.to_s).to include('https://dap.digitalgov.gov')
+        expect(doc.to_s).to include('https://www.googletagmanager.com/gtag/js')
+      end
     end
   end
 end


### PR DESCRIPTION
https://cm-jira.usa.gov/browse/LG-11829

As requested by GSA's Office of Strategic Communication (OSC), we are being asked to add this analytics tracking tag to the site. (Search email for "Google Analytics 4 Migration")

The code changes here assume a configurable measurement ID, which will be assigned in production prior to launch.

📜 Testing Plan

Configure a local measurement ID, either using a real value or a fake one like "G-XXXXXXXXXX".

# config.yml
osc_analytics_ga_measurement_id: 'G-XXXXXXXXXX'

- Go to http://localhost:4000/
- Open developer tools
- Observe no CSP errors related to `https://www.googletagmanager.com/gtag/js` in console
- Observe network collection traffic for analytics in Network tab

See related: https://github.com/18F/identity-site/pull/1189
