### PR TITLE
Remove unused "whitelist" configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,9 +11,6 @@ plugins:
   - jekyll-redirect-from
   - jekyll-sitemap
 
-whitelist:
-  - jekyll-redirect-from
-
 copy_to_destination:
   - node_modules/@18f/identity-design-system/dist/assets
 


### PR DESCRIPTION
Removes the unused `whitelist` configuration from `_config.yml`.

**Why?**

- This configuration is relevant for use with [the `--safe` flag](https://jekyllrb.com/docs/configuration/options/), which we do not currently use
   - Use of the flag would also produce an inconsistent result currently, since only one of the two plugins in use is currently allowlisted
- Avoids an unnecessary exclusionary term