### PR TITLE
fix erroneous quotation mark 

### DIFF
--- a/_pages/user-experience/getting-started.md
+++ b/_pages/user-experience/getting-started.md
@@ -50,7 +50,7 @@ Optional: [Add FAQ content to inform users about Login.gov]({{site.baseurl}}/use
 
 ### Add to your agency's application or website
 
-<ul class="usa-icon-list"">
+<ul class="usa-icon-list">
   <li class="usa-icon-list__item">
     {% include green_icon.html content=button_ux %}       
   </li>


### PR DESCRIPTION
Fixing an erroneous quotation mark in the HTML for the getting started page 

caught during acceptance, see thread here: https://gsa-tts.slack.com/archives/C05E50XNN8Z/p1702322731308009