### PR TITLE
Fix “reigster” typo

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -17,7 +17,7 @@ layout: home
     <ol class="usa-process-list usa-prose margin-bottom-4">
       <li class="usa-process-list__item">
         <p>
-          Your integration with Login.gov starts in the <a href="https://dashboard.int.identitysandbox.gov/" class="usa-link">dashboard</a> where you can reigster your app.
+          Your integration with Login.gov starts in the <a href="https://dashboard.int.identitysandbox.gov/" class="usa-link">dashboard</a> where you can register your app.
         </p>
       </li>
       <li class="usa-process-list__item">


### PR DESCRIPTION
Rachel discovered a typo on the homepage of the developer docs and noted it in Slack at https://gsa-tts.slack.com/archives/C01SU3NB9T3/p1702914309550849.

This PR fixes `reigster` to be `register`.