### PR TITLE
UX Guide - Getting Started - fix spacing between headers and text

### DIFF
--- a/_pages/user-experience/getting-started.md
+++ b/_pages/user-experience/getting-started.md
@@ -50,7 +50,7 @@ Optional: [Add FAQ content to inform users about Login.gov]({{site.baseurl}}/use
 
 ### Add to your agency's application or website
 
-<ul class="usa-icon-list">
+<ul class="usa-icon-list padding-top-2">
   <li class="usa-icon-list__item">
     {% include green_icon.html content=button_ux %}       
   </li>
@@ -64,7 +64,7 @@ Optional: [Add FAQ content to inform users about Login.gov]({{site.baseurl}}/use
 
 ### Configure in the [dashboard](https://dashboard.int.identitysandbox.gov/)
 
-<ul class="usa-icon-list padding-bottom-4">
+<ul class="usa-icon-list padding-bottom-4 padding-top-2">
  <li class="usa-icon-list__item">
     {% include green_icon.html content=logo_ux %}
  </li>


### PR DESCRIPTION
Adding utility classes to provide extra padding between text and headers on getting started page for the UX guide to more closely match the FIgma design

[Further discussion around vertical space + headers in Slack here ](https://gsa-tts.slack.com/archives/C01JVKYE4KD/p1702914619083849)

Old spacing 
![Screenshot 2023-12-18 at 11 41 13 AM](https://github.com/18F/identity-dev-docs/assets/6639858/3b385120-21bf-4ffa-a0bf-1c5ddad0cf22)

New spacing 
![Screenshot 2023-12-18 at 11 41 43 AM](https://github.com/18F/identity-dev-docs/assets/6639858/cb745520-c3bc-414c-be88-70caa66cf739)

