### PR TITLE
Document how to simulate an individual state MVA returning an error

### DIFF
--- a/_pages/testing.md
+++ b/_pages/testing.md
@@ -157,7 +157,9 @@ To simulate issues with proofing vendor responses, create a YAML file that inclu
 | Parse | parse error in vendor response |
 | Time | vendor timeout |
 
-To simulate failure to verify a zipcode, enter “00000” for the user's zipcode.
+To simulate failure to verify a zipcode, enter `00000` for the user's zipcode.
+
+See also: [Individual state MVA errors](#individual-state-mva-errors)
 
 Sample YAML file:
 {% include yaml_download.md filename="proofing_vendor_error.yml" %}
@@ -166,8 +168,14 @@ Sample YAML file:
 
 Login.gov collects the document number of a drivers license or state ID card automatically during the proofing process. This document is checked against issuing source data, along with user information, such as address.
 
-To simulate a verification failure, submit `00000000` as the `state_id_number` for [any jurisdiction](https://github.com/18F/identity-idp/blob/2022-07-21T171117/config/application.yml.default#L21) where issuing source verification is enabled.
+To simulate a verification failure, submit `00000000` as the `state_id_number` and [any jurisdiction](https://github.com/18F/identity-idp/blob/2022-07-21T171117/config/application.yml.default#L21) where issuing source verification is enabled for `state_id_jurisdiction`.
 
+### Individual state MVA errors
+
+To simulate an individual state yielding an error when asked to verify a drivers license, use `mvatimeout` for `state_id_number` and `WA` for `state_id_jurisdiction`. You can use [any jurisdiction](https://github.com/18F/identity-idp/blob/2022-07-21T171117/config/application.yml.default#L21) where issuing source verification is enabled for `state_id_jurisdiction`, for example `WA`.
+
+Sample YAML file:
+{% include yaml_download.md filename="individual_state_error.yml" %}
 ### Phone number verification
 
 Login.gov collects a phone number during the proofing process. In the production environment, Login.gov checks that this phone number is associated with the applicant. The following phone numbers simulate specific events:

--- a/assets/yaml/individual_state_error.yml
+++ b/assets/yaml/individual_state_error.yml
@@ -1,0 +1,15 @@
+document:
+  type: license
+  first_name: Susan
+  last_name: Smith
+  middle_name: Q
+  address1: 1 Microsoft Way
+  address2: Apt 3
+  city: Bayside
+  state: NY
+  zipcode: '11364'
+  dob: 10/06/1938
+  phone: +1 314-555-1212
+  state_id_number: "mvatimeout"
+  state_id_type: "drivers_license"
+  state_id_jurisdiction: "WA"


### PR DESCRIPTION
Document how to simulate an individual state MVA returning an error during proofing a drivers license.

Testing - Testing Identity Proofing - [Individual State MVA Errors](https://federalist-14ccf384-8bd5-4e30-aa95-a5fe5894e3c1.sites.pages.cloud.gov/preview/18f/identity-dev-docs/sonia-document-mvatimeout-error-simulation/testing/#individual-state-mva-errors)