### PR TITLE
Update documentation and yml files for selfie

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,7 @@ This site uses the [U.S. Web Design Standards](https://standards.usa.gov). To up
 2. Copy contents to `assets/`
 3. Rename directory to `uswds`
 4. Download latest [anchor.js](https://github.com/bryanbraun/anchorjs) and put in `assets/js/`
+
+#### YAML files
+
+When updating a `yml` file, you only need to update the version in the `/assets` directory. This is symlinked to the `_includes` directory.

--- a/_pages/testing.md
+++ b/_pages/testing.md
@@ -141,7 +141,6 @@ Alert names with attention or failed values show under `failed_alerts`. Only pas
 **NOTES:**
 
 - There are configurations of the above yaml file that cannot happen in real vendor responses. It is possible there will be unexpected outcomes in those cases.
-- When using the `yaml` files for local dev, only the yml file supplied to the `back` is evaluated.
 
 ### Personal information verification
 

--- a/_pages/testing.md
+++ b/_pages/testing.md
@@ -93,7 +93,9 @@ Login.gov prompts users to upload the front and back of their documents during p
 
 #### Data testing
 
-A YAML file can be uploaded instead of a State ID image to trigger different behaviors. You will upload this text file for the front and back for the State ID, and possibly the selfie. The YAML file can be used to simulate the reading of certain attributes from the State ID or selfie. Here is an example YAML file that does that:
+⚠️ Only the YAML file in the `back` upload box is used on submission. For that reason, it's good practice to upload the same yaml file in all three upload boxes to avoid confusion when testing.
+
+A YAML file can be uploaded instead of a State ID image to trigger different behaviors. You will upload the same YAML file for the front and back of the State ID, and also the selfie (if that field appears). Different YAML files can be used to simulate the reading of certain attributes from the State ID or selfie. Here is an example YAML file that does that:
 
 {% include yaml_download.md filename="proofing.yml" %}
 

--- a/_pages/testing.md
+++ b/_pages/testing.md
@@ -93,7 +93,7 @@ Login.gov prompts users to upload the front and back of their documents during p
 
 #### Data testing
 
-A YAML file can be uploaded instead of a State ID image to trigger different behaviors. You will upload this text file for the front and back for the State ID. The YAML file can be used to simulate the reading of certain attributes from the State ID. Here is an example YAML file that does that:
+A YAML file can be uploaded instead of a State ID image to trigger different behaviors. You will upload this text file for the front and back for the State ID, and possibly the selfie. The YAML file can be used to simulate the reading of certain attributes from the State ID or selfie. Here is an example YAML file that does that:
 
 {% include yaml_download.md filename="proofing.yml" %}
 
@@ -136,7 +136,10 @@ Alert names with attention or failed values show under `failed_alerts`. Only pas
       - name: Visible Photo Characteristics
 ```
 
-**NOTE:** Even if you put all passing information into the test yaml file it will still produce an error. There are configurations of the above yaml file that cannot happen in real vendor responses. It is possible there will be unexpected outcomes in those cases.
+**NOTES:**
+
+- There are configurations of the above yaml file that cannot happen in real vendor responses. It is possible there will be unexpected outcomes in those cases.
+- When using the `yaml` files for local dev, only the yml file supplied to the `back` is evaluated.
 
 ### Personal information verification
 

--- a/assets/yaml/sample_full_error.yml
+++ b/assets/yaml/sample_full_error.yml
@@ -19,5 +19,5 @@ passed_alerts:
   - name: Visible Pattern
     result: Passed
 portrait_match_results:
-  face_match_result: Pass # values: Pass, Fail
-  face_error_message: 'Successful. Liveness: Live' #values: 'Successful. Liveness: Live', 'Liveness: NotLive', 'Liveness: PoorQuality'
+  FaceMatchResult: Pass # returns the portrait match result - values: Pass, Fail
+  FaceErrorMessage: 'Successful. Liveness: Live' # returns the liveness result - values: 'Successful. Liveness: Live', 'Liveness: NotLive', 'Liveness: PoorQuality'

--- a/assets/yaml/sample_full_error.yml
+++ b/assets/yaml/sample_full_error.yml
@@ -18,4 +18,6 @@ failed_alerts:
 passed_alerts:
   - name: Visible Pattern
     result: Passed
-liveness_result: Fail # values: Pass, Fail
+portrait_match_results:
+  face_match_result: Pass # values: Pass, Fail
+  face_error_message: 'Successful. Liveness: Live' #values: 'Successful. Liveness: Live', 'Liveness: NotLive', 'Liveness: PoorQuality'


### PR DESCRIPTION
This change:

- updates the `sample_full_error.yml` for selfie entries, with the possible values notated
- updates the text in the yml section to include selfie
- removes a note that I don't think is true anymore (`Even if you put all passing information into the test yaml file it will still produce an error.` - you can upload a yml file that passes doc auth)
- updates the yml docs to include a note that only the back image is evaluated 
- updates the general documentation for a note about changing yml files since I had trouble finding a note about it

Note: These changes should not be merged until https://github.com/18F/identity-idp/pull/9882 is merged.