### PR TITLE
fix Lookbook embed width on desktop sizes

### DIFF
--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -176,6 +176,10 @@ button.code-button:hover {
     padding-top: 0px;
   }
 
+  .lookbook-embed-container {
+    width: 700px;
+  }
+
   .code-snippet-column::before {
     content: "";
     right: -15px;


### PR DESCRIPTION
Minor aesthetic fix

Reduce the width of the embed to 700px on desktop (it was taking up full width before) 
