### PR TITLE
Clarify OIDC = OpenID Connect

### DIFF
--- a/_pages/oidc/getting-started.md
+++ b/_pages/oidc/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: OpenID Connect
 lead: >
-   [OpenID Connect](http://openid.net){:class="usa-link--external"} is a simple identity layer built on top of the OAuth 2.0 protocol. Login.gov supports [version 1.0](http://openid.net/specs/openid-connect-core-1_0.html){:class="usa-link--external"} of the specification and conforms to the [iGov Profile](https://openid.net/wg/igov){:class="usa-link--external"}.
+   [OpenID Connect](http://openid.net){:class="usa-link--external"} (OIDC) is a simple identity layer built on top of the OAuth 2.0 protocol. Login.gov supports [version 1.0](http://openid.net/specs/openid-connect-core-1_0.html){:class="usa-link--external"} of the specification and conforms to the [iGov Profile](https://openid.net/wg/igov){:class="usa-link--external"}.
 redirect_from:
   - /openid-connect/
   - /oidc/
@@ -30,7 +30,7 @@ sidenav:
 
 ---
 {% capture implicit_flow_warning %}
-We do not support the OpenID Connect “implicit flow” with client_secret because it is not recommended by the OAuth group for security reasons
+We do not support the OpenID Connect (OIDC) “implicit flow” with client_secret because it is not recommended by the OAuth group for security reasons
 {% endcapture %}
 {% include alert.html content=implicit_flow_warning alert_class="usa-alert--warning" %}
 
@@ -59,16 +59,16 @@ The following implementation methods of OIDC are not supported by Login.gov for 
 You are able to test authentication methods in real time with a testing account in our sandbox environment. To start, navigate to the [Login Partner Dashboard Sandbox](https://dashboard.int.identitysandbox.gov) and follow the steps below:
 
 - Select the “Sign-in” button to create a new account. Anyone with a .gov or .mil email address may request an account. 
-- Create a new team - see [Testing](https://developers.login.gov/testing/) page for instructions
+- Create a new team - see [Testing](https://developers.login.gov/testing/) page for instructions.
 -  Create a certificate - before creating your application you'll need to create a certificate that will be used to sign your requests. You can create a certificate using openssl. The example command to create the certificate from your terminal is:
     - `openssl req -nodes -x509 -days 365 -newkey rsa:2048 -keyout private.pem -out public.crt`
-- Create an application, at which point you will need to decide between private_key_jwt or PKCE
+- Create an application, at which point you will need to decide between private_key_jwt or PKCE.
 
 It is important to note that your Login.gov production account and your Login.gov sandbox account are two separate accounts.
 
 ### Auto-discovery
 
-Consistent with the specification, Login.gov provides a JSON endpoint for OpenID Connect auto-discovery at 
+Consistent with the specification, Login.gov provides a JSON endpoint for OIDC auto-discovery at 
 `/.well-known/openid-configuration`. 
 
 Integration URI:


### PR DESCRIPTION
[per LG-11619,](https://cm-jira.usa.gov/browse/LG-11619) adding clarifying language to show that OIDC is the abbreviation for OpenID Connect by adding (OIDC) following the full spelling and changing subsequent full spellings to the abbreviation.