### PR TITLE
Update logout.md OIDC=OpenID Connect

### DIFF
--- a/_pages/oidc/logout.md
+++ b/_pages/oidc/logout.md
@@ -1,7 +1,7 @@
 ---
 title: OpenID Connect
 lead: >
-    [OpenID Connect](http://openid.net){:class="usa-link--external"} is a simple identity layer built on top of the OAuth 2.0 protocol. Login.gov supports [version 1.0](http://openid.net/specs/openid-connect-core-1_0.html){:class="usa-link--external"} of the specification and conforms to the [iGov Profile](https://openid.net/wg/igov){:class="usa-link--external"}.
+    [OpenID Connect](http://openid.net){:class="usa-link--external"} (OIDC) is a simple identity layer built on top of the OAuth 2.0 protocol. Login.gov supports [version 1.0](http://openid.net/specs/openid-connect-core-1_0.html){:class="usa-link--external"} of the specification and conforms to the [iGov Profile](https://openid.net/wg/igov){:class="usa-link--external"}.
 sidenav:
   - text: Getting started
     href: "oidc/getting-started/"


### PR DESCRIPTION
per LG-11619, adding clarifying language to show that OIDC is the abbreviation for OpenID Connect by adding (OIDC) following the full spelling and changing subsequent full spellings to the abbreviation.