### PR TITLE
Update description meta tags to remove Markdown

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -20,8 +20,8 @@
     <meta property="og:title" content="{{ title }}">
 
     {% if page.lead -%}
-      <meta name="description" content="{{ page.lead | strip_html }}">
-      <meta property="og:description" content="{{ page.lead | strip_html }}">
+      <meta name="description" content="{{ page.lead | markdownify | strip_html | strip }}">
+      <meta property="og:description" content="{{ page.lead | markdownify | strip_html | strip }}">
     {% endif -%}
 
     <meta name="twitter:card" value="summary">

--- a/spec/page.md_spec.rb
+++ b/spec/page.md_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe 'all pages' do
         expect(doc.to_s).to include('https://dap.digitalgov.gov')
         expect(doc.to_s).to include('https://www.googletagmanager.com/gtag/js')
       end
+
+      it 'does not include markdown markup in description meta tags', aggregate_failures: true do
+        description = doc.at_css('meta[name=description]')
+        expect(description[:content]).to_not(include('](')) if description
+
+        og_description = doc.at_css('meta[property="og:description"]')
+        expect(og_description[:content]).to_not(include('](')) if og_description
+      end
     end
   end
 end


### PR DESCRIPTION
**Why**: So they can be embedded and summarized more easily

I spotted this preview in a chat which rendered poorly (see screenshots below)

So to fix that I added markdown parsing to the `<meta>` tag generation

| before | after |
| ---- | ---- |
| <img width="422" alt="Screenshot 2024-01-25 at 3 26 36 PM" src="https://github.com/18F/identity-dev-docs/assets/458784/254042e8-f9d5-4c0e-8ada-c2dd1e5521cd"> | <img width="393" alt="Screenshot 2024-01-25 at 3 43 51 PM" src="https://github.com/18F/identity-dev-docs/assets/458784/d4fc13f5-9e9e-447e-b58d-4004af838d94"> |
| <img width="1124" alt="Screenshot 2024-01-25 at 3 41 28 PM" src="https://github.com/18F/identity-dev-docs/assets/458784/9f106fe5-9c54-4247-b24f-9ab352662d6e"> | <img width="1230" alt="Screenshot 2024-01-25 at 3 41 50 PM" src="https://github.com/18F/identity-dev-docs/assets/458784/e9cf9976-3946-4230-ab7d-e0afabee4801"> |

