### PR TITLE
LG-12216: Add help text section to UX Guide

### DIFF
--- a/_pages/user-experience/agency-logo.md
+++ b/_pages/user-experience/agency-logo.md
@@ -7,6 +7,8 @@ sidenav:
     href: "user-experience/getting-started/"
   - text: Sign-in and sign-out buttons
     href: "user-experience/sign-in-sign-out/"
+  - text: Help text guidance
+    href: "user-experience/help-text/"
   - text: Your agency logo
     href: "user-experience/agency-logo/"
     links:

--- a/_pages/user-experience/cancel-url.md
+++ b/_pages/user-experience/cancel-url.md
@@ -7,6 +7,8 @@ sidenav:
     href: "user-experience/getting-started/"
   - text: Sign-in and sign-out buttons
     href: "user-experience/sign-in-sign-out/"
+  - text: Help text guidance
+    href: "user-experience/help-text/"
   - text: Your agency logo
     href: "user-experience/agency-logo/"
   - text: Cancel URL

--- a/_pages/user-experience/failure-proof.md
+++ b/_pages/user-experience/failure-proof.md
@@ -7,6 +7,8 @@ sidenav:
     href: "user-experience/getting-started/"
   - text: Sign-in and sign-out buttons
     href: "user-experience/sign-in-sign-out/"
+  - text: Help text guidance
+    href: "user-experience/help-text/"
   - text: Your agency logo
     href: "user-experience/agency-logo/"
   - text: Cancel URL

--- a/_pages/user-experience/faq-content.md
+++ b/_pages/user-experience/faq-content.md
@@ -7,6 +7,8 @@ sidenav:
     href: "user-experience/getting-started/"
   - text: Sign-in and sign-out buttons
     href: "user-experience/sign-in-sign-out/"
+  - text: Help text guidance
+    href: "user-experience/help-text/"
   - text: Your agency logo
     href: "user-experience/agency-logo/"
   - text: Cancel URL

--- a/_pages/user-experience/getting-started.md
+++ b/_pages/user-experience/getting-started.md
@@ -10,6 +10,8 @@ sidenav:
     href: "user-experience/getting-started/"
   - text: Sign-in and sign-out buttons
     href: "user-experience/sign-in-sign-out/"
+  - text: Help text guidance
+    href: "user-experience/help-text/"
   - text: Your agency logo
     href: "user-experience/agency-logo/"
   - text: Cancel URL

--- a/_pages/user-experience/help-text.md
+++ b/_pages/user-experience/help-text.md
@@ -1,0 +1,56 @@
+---
+title: User Experience
+lead: >
+  Create a simple and consistent experience for your Login.gov users
+sidenav:
+  - text: Getting started
+    href: "user-experience/getting-started/"
+  - text: Sign-in and sign-out buttons
+    href: "user-experience/sign-in-sign-out/"
+  - text: Help text guidance
+    href: "user-experience/help-text/"
+  - text: Your agency logo
+    href: "user-experience/agency-logo/"
+  - text: Cancel URL
+    href: "user-experience/cancel-url/"
+  - text: Failure to proof URL
+    href: "user-experience/failure-proof/"
+  - text: Knowledge articles
+    href: "user-experience/knowledge-articles/"
+  - text: FAQ content
+    href: "user-experience/faq-content/"
+
+---
+
+##  Help text guidance
+
+You may include help text to alert the users to specific information that will assist them in logging in, signing up, and logging out. The help text section of the app configuration workflow allows you to choose from the default help text options or request custom help text specific to your integration. 
+
+Custom help text should follow the guidelines below to be included in your integration: 
+
+
+<ul class="usa-icon-list padding-bottom-4 padding-top-2">
+ <li class="usa-icon-list__item">
+    {% include icon_list.html icon_name="check_circle" content="Help text should be brief, specific, and useful. It should add to the information already displayed on the page." style="text-success" %}
+ </li>
+ <li class="usa-icon-list__item">
+    {% include icon_list.html icon_name="check_circle" content="Include agency-specific contact information if needed." style="text-success" %}
+ </li>
+ <li class="usa-icon-list__item">
+    {% include icon_list.html icon_name="check_circle" content="Include Spanish and French translations of your custom help text." style="text-success" %}
+ </li>
+ <li class="usa-icon-list__item">
+     {% include icon_list.html icon_name="cancel" style="text-error" content="Repeat general instructions to complete the process (eg Sign in here)."  %}
+  </li>
+  <li class="usa-icon-list__item">
+     {% include icon_list.html icon_name="cancel" style="text-error" content="Include legal disclaimers. These should be displayed on a separate page."  %}
+  </li>
+  <li class="usa-icon-list__item">
+     {% include icon_list.html icon_name="cancel" style="text-error" content="Use link text like “click here” or “learn more”. Link text should be descriptive and inform the user what they are linking to."  %}
+  </li>
+</ul>
+
+
+To request custom help text, reach out to the [Partner Support Help Desk](https://zendesk.login.gov/).  
+
+[Next step: Add your agency logo]({{ site.baseurl }}/user-experience/agency-logo/)

--- a/_pages/user-experience/knowledge-articles.md
+++ b/_pages/user-experience/knowledge-articles.md
@@ -7,6 +7,8 @@ sidenav:
     href: "user-experience/getting-started/"
   - text: Sign-in and sign-out buttons
     href: "user-experience/sign-in-sign-out/"
+  - text: Help text guidance
+    href: "user-experience/help-text/"
   - text: Your agency logo
     href: "user-experience/agency-logo/"
   - text: Cancel URL

--- a/_pages/user-experience/sign-in-sign-out.md
+++ b/_pages/user-experience/sign-in-sign-out.md
@@ -7,6 +7,8 @@ sidenav:
     href: "user-experience/getting-started/"
   - text: Sign-in and sign-out buttons
     href: "user-experience/sign-in-sign-out/"
+  - text: Help text guidance
+    href: "user-experience/help-text/"
   - text: Your agency logo
     href: "user-experience/agency-logo/"
   - text: Cancel URL
@@ -253,4 +255,4 @@ Users need a clearly marked button to sign out after a user has signed in to you
   </div>
 </div>
 
-[Next step: Add your agency logo]({{ site.baseurl }}/user-experience/agency-logo/)
+[Next step: Help text guidance]({{ site.baseurl }}/user-experience/help-text/)


### PR DESCRIPTION
[LG-12216](https://cm-jira.usa.gov/browse/LG-12216?filter=-1
)
Needed to add a new section to the UX guide for help text best practices for partners

Google doc with help text guidance:
https://docs.google.com/document/d/1o79o-j_1DTw1V8v2sMmF6AG9qB9o3n3usAkDbhvZxcs/edit
