### PR TITLE
Add CSS to fix alert icons

### DIFF
--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -146,12 +146,6 @@ button.code-button:hover {
   width: 230px;
 }
 
-.usa-alert {
-  .usa-alert__body::before {
-    height: 1rem;
-  }
-}
-
 @media (min-width: 1024px) {
   .code-snippet-column {
     background-color: transparent;

--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -146,6 +146,12 @@ button.code-button:hover {
   width: 230px;
 }
 
+.usa-alert {
+  .usa-alert__body::before {
+    height: 1rem;
+  }
+}
+
 @media (min-width: 1024px) {
   .code-snippet-column {
     background-color: transparent;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "CC0-1.0",
       "dependencies": {
-        "@18f/identity-build-sass": "^1.1.0",
-        "@18f/identity-design-system": "^7.1.0"
+        "@18f/identity-build-sass": "^3.0.0",
+        "@18f/identity-design-system": "^8.1.2"
       },
       "devDependencies": {
         "@18f/eslint-plugin-identity": "^2.0.0",
@@ -65,25 +65,29 @@
       }
     },
     "node_modules/@18f/identity-build-sass": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@18f/identity-build-sass/-/identity-build-sass-1.1.0.tgz",
-      "integrity": "sha512-nJeNQB+8tiQsvc6oh7UON1EsRK1MTuc9n5bMS9MIS2Mxa6mKkZDSGBdSR2TINAEdgQLlLlDOziRNTez4Um29jg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-build-sass/-/identity-build-sass-3.0.0.tgz",
+      "integrity": "sha512-GcSvtqai+8VO5jAAklx+pkzQEeYwgyMswY+752VrCQJ2zcfHy+VxMmYHJAEJ7+lKzcD/KhqSHkzwypMzcUtrVg==",
       "dependencies": {
-        "browserslist": "^4.21.5",
+        "@aduth/is-dependency": "^1.0.0",
+        "browserslist": "^4.22.3",
         "chokidar": "^3.5.3",
-        "lightningcss": "^1.16.1",
-        "sass-embedded": "^1.56.1"
+        "lightningcss": "^1.23.0",
+        "sass-embedded": "^1.70.0"
       },
       "bin": {
         "build-sass": "cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@18f/identity-design-system": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.1.0.tgz",
-      "integrity": "sha512-/DChj/p9hju15HMQCtukId2POIhHo25SjZzKh11bklkTICLOBEpPc1GRIkWUIDv5WU/N5DtX1saFafqs+HKnEA==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-8.1.2.tgz",
+      "integrity": "sha512-EvhnRvqOWmvjAdV2EedvSeoiN55RFA4RqAIsPTScw1N6QstbXEzJmDA242k3X81nf6Kd1yRFKxrKxNdl1CbmDQ==",
       "dependencies": {
-        "@uswds/uswds": "^3.4.1"
+        "@uswds/uswds": "^3.7.1"
       },
       "engines": {
         "node": ">=12",
@@ -99,6 +103,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@aduth/is-dependency": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aduth/is-dependency/-/is-dependency-1.0.0.tgz",
+      "integrity": "sha512-1CJwTd6B6XDb6HETcHMwjRmQLQi2FgjM1rYUO6wf1yizKVPC9V66vmvVCtgePMzWmhsLqdhOPLWt+fNvG46FoA=="
+    },
     "node_modules/@babel/runtime": {
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
@@ -113,9 +122,9 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.2.0.tgz",
-      "integrity": "sha512-MBVuQMOBHxgGnZ9XCUIi8WOy5O/T4ma3TduCRhRvndv3UDbG9cHgd8h6nOYSGyBYPEvXf1z9nTwhp8mVIDbq2g=="
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.7.2.tgz",
+      "integrity": "sha512-i5GE2Dk5ekdlK1TR7SugY4LWRrKSfb5T1Qn4unpIMbfxoeGKERKQ59HG3iYewacGD10SR7UzevfPnh6my4tNmQ=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -274,11 +283,11 @@
       "dev": true
     },
     "node_modules/@uswds/uswds": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.4.1.tgz",
-      "integrity": "sha512-eLYbWUqf9eWUa2P6CO3ckIjtQyM3AylrIOHxN5gYG3P62TDd3FzRDyoACfvOe6CNk0w0PqXWJnuPzxpNoOgWNA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.7.1.tgz",
+      "integrity": "sha512-32u2S50bf5dwIujebqL+f1Jgx2rmRrpxcaccSZzdo3Qv9HaDUdcmeavlrxHqN30edHc7p8kRPjvjevOmOJKB7w==",
       "dependencies": {
-        "classlist-polyfill": "1.0.3",
+        "classlist-polyfill": "1.2.0",
         "object-assign": "4.1.1",
         "receptor": "1.0.0",
         "resolve-id-refs": "0.1.0"
@@ -604,9 +613,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
-      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -615,13 +624,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001449",
-        "electron-to-chromium": "^1.4.284",
-        "node-releases": "^2.0.8",
-        "update-browserslist-db": "^1.0.10"
+        "caniuse-lite": "^1.0.30001587",
+        "electron-to-chromium": "^1.4.668",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -674,9 +687,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001473",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz",
-      "integrity": "sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==",
+      "version": "1.0.30001589",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001589.tgz",
+      "integrity": "sha512-vNQWS6kI+q6sBlHbh71IIeC+sRwK2N3EDySc/updIGhIee2x5z00J4c1242/5/d6EpEMdOnk/m+6tuk4/tcsqg==",
       "funding": [
         {
           "type": "opencollective",
@@ -747,9 +760,9 @@
       }
     },
     "node_modules/classlist-polyfill": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.0.3.tgz",
-      "integrity": "sha512-bDLDUsSg5LYFWsc2hphtG6ulyaCFSupdEBU3wxNECKWHnyPVvY8EB9Wbt9DzWkstWclFZhDaZK/VnEK/DmqE/Q=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ=="
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -936,9 +949,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.348",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.348.tgz",
-      "integrity": "sha512-gM7TdwuG3amns/1rlgxMbeeyNoBFPa+4Uu0c7FeROWh4qWmvSOnvcslKmWy51ggLKZ2n/F/4i2HJ+PVNxH9uCQ=="
+      "version": "1.4.680",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.680.tgz",
+      "integrity": "sha512-4nToZ5jlPO14W82NkF32wyjhYqQByVaDmLy4J2/tYcAbJfgO2TKJC780Az1V13gzq4l73CJ0yuyalpXvxXXD9A=="
     },
     "node_modules/element-closest": {
       "version": "2.0.2",
@@ -1072,9 +1085,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
       "engines": {
         "node": ">=6"
       }
@@ -1944,9 +1957,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
-      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg=="
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
+      "integrity": "sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -2540,9 +2553,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.19.0.tgz",
-      "integrity": "sha512-yV5UR7og+Og7lQC+70DA7a8ta1uiOPnWPJfxa0wnxylev5qfo4P+4iMpzWAdYWOca4jdNQZii+bDL/l+4hUXIA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.23.0.tgz",
+      "integrity": "sha512-SEArWKMHhqn/0QzOtclIwH5pXIYQOUEkF8DgICd/105O+GCgd7jxjNod/QPnBCSWvpRHQBGVz5fQ9uScby03zA==",
       "dependencies": {
         "detect-libc": "^1.0.3"
       },
@@ -2554,20 +2567,21 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.19.0",
-        "lightningcss-darwin-x64": "1.19.0",
-        "lightningcss-linux-arm-gnueabihf": "1.19.0",
-        "lightningcss-linux-arm64-gnu": "1.19.0",
-        "lightningcss-linux-arm64-musl": "1.19.0",
-        "lightningcss-linux-x64-gnu": "1.19.0",
-        "lightningcss-linux-x64-musl": "1.19.0",
-        "lightningcss-win32-x64-msvc": "1.19.0"
+        "lightningcss-darwin-arm64": "1.23.0",
+        "lightningcss-darwin-x64": "1.23.0",
+        "lightningcss-freebsd-x64": "1.23.0",
+        "lightningcss-linux-arm-gnueabihf": "1.23.0",
+        "lightningcss-linux-arm64-gnu": "1.23.0",
+        "lightningcss-linux-arm64-musl": "1.23.0",
+        "lightningcss-linux-x64-gnu": "1.23.0",
+        "lightningcss-linux-x64-musl": "1.23.0",
+        "lightningcss-win32-x64-msvc": "1.23.0"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.19.0.tgz",
-      "integrity": "sha512-wIJmFtYX0rXHsXHSr4+sC5clwblEMji7HHQ4Ub1/CznVRxtCFha6JIt5JZaNf8vQrfdZnBxLLC6R8pC818jXqg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.23.0.tgz",
+      "integrity": "sha512-kl4Pk3Q2lnE6AJ7Qaij47KNEfY2/UXRZBT/zqGA24B8qwkgllr/j7rclKOf1axcslNXvvUdztjo4Xqh39Yq1aA==",
       "cpu": [
         "arm64"
       ],
@@ -2584,9 +2598,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.19.0.tgz",
-      "integrity": "sha512-Lif1wD6P4poaw9c/4Uh2z+gmrWhw/HtXFoeZ3bEsv6Ia4tt8rOJBdkfVaUJ6VXmpKHALve+iTyP2+50xY1wKPw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.23.0.tgz",
+      "integrity": "sha512-KeRFCNoYfDdcolcFXvokVw+PXCapd2yHS1Diko1z1BhRz/nQuD5XyZmxjWdhmhN/zj5sH8YvWsp0/lPLVzqKpg==",
       "cpu": [
         "x64"
       ],
@@ -2602,10 +2616,29 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.23.0.tgz",
+      "integrity": "sha512-xhnhf0bWPuZxcqknvMDRFFo2TInrmQRWZGB0f6YoAsZX8Y+epfjHeeOIGCfAmgF0DgZxHwYc8mIR5tQU9/+ROA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.19.0.tgz",
-      "integrity": "sha512-P15VXY5682mTXaiDtbnLYQflc8BYb774j2R84FgDLJTN6Qp0ZjWEFyN1SPqyfTj2B2TFjRHRUvQSSZ7qN4Weig==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.23.0.tgz",
+      "integrity": "sha512-fBamf/bULvmWft9uuX+bZske236pUZEoUlaHNBjnueaCTJ/xd8eXgb0cEc7S5o0Nn6kxlauMBnqJpF70Bgq3zg==",
       "cpu": [
         "arm"
       ],
@@ -2622,9 +2655,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.19.0.tgz",
-      "integrity": "sha512-zwXRjWqpev8wqO0sv0M1aM1PpjHz6RVIsBcxKszIG83Befuh4yNysjgHVplF9RTU7eozGe3Ts7r6we1+Qkqsww==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.23.0.tgz",
+      "integrity": "sha512-RS7sY77yVLOmZD6xW2uEHByYHhQi5JYWmgVumYY85BfNoVI3DupXSlzbw+b45A9NnVKq45+oXkiN6ouMMtTwfg==",
       "cpu": [
         "arm64"
       ],
@@ -2641,9 +2674,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.19.0.tgz",
-      "integrity": "sha512-vSCKO7SDnZaFN9zEloKSZM5/kC5gbzUjoJQ43BvUpyTFUX7ACs/mDfl2Eq6fdz2+uWhUh7vf92c4EaaP4udEtA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.23.0.tgz",
+      "integrity": "sha512-cU00LGb6GUXCwof6ACgSMKo3q7XYbsyTj0WsKHLi1nw7pV0NCq8nFTn6ZRBYLoKiV8t+jWl0Hv8KkgymmK5L5g==",
       "cpu": [
         "arm64"
       ],
@@ -2660,9 +2693,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.19.0.tgz",
-      "integrity": "sha512-0AFQKvVzXf9byrXUq9z0anMGLdZJS+XSDqidyijI5njIwj6MdbvX2UZK/c4FfNmeRa2N/8ngTffoIuOUit5eIQ==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.23.0.tgz",
+      "integrity": "sha512-q4jdx5+5NfB0/qMbXbOmuC6oo7caPnFghJbIAV90cXZqgV8Am3miZhC4p+sQVdacqxfd+3nrle4C8icR3p1AYw==",
       "cpu": [
         "x64"
       ],
@@ -2679,9 +2712,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.19.0.tgz",
-      "integrity": "sha512-SJoM8CLPt6ECCgSuWe+g0qo8dqQYVcPiW2s19dxkmSI5+Uu1GIRzyKA0b7QqmEXolA+oSJhQqCmJpzjY4CuZAg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.23.0.tgz",
+      "integrity": "sha512-G9Ri3qpmF4qef2CV/80dADHKXRAQeQXpQTLx7AiQrBYQHqBjB75oxqj06FCIe5g4hNCqLPnM9fsO4CyiT1sFSQ==",
       "cpu": [
         "x64"
       ],
@@ -2698,9 +2731,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.19.0.tgz",
-      "integrity": "sha512-C+VuUTeSUOAaBZZOPT7Etn/agx/MatzJzGRkeV+zEABmPuntv1zihncsi+AyGmjkkzq3wVedEy7h0/4S84mUtg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.23.0.tgz",
+      "integrity": "sha512-1rcBDJLU+obPPJM6qR5fgBUiCdZwZLafZM5f9kwjFLkb/UBNIzmae39uCSmh71nzPCTXZqHbvwu23OWnWEz+eg==",
       "cpu": [
         "x64"
       ],
@@ -2829,9 +2862,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
-      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -3471,9 +3504,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -3511,34 +3544,115 @@
       }
     },
     "node_modules/sass-embedded": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.60.0.tgz",
-      "integrity": "sha512-pTCcbAaymfRX0Zkc17fGAVRBX3PPnj0vmWg93oGpeP/IMncxa58s+OPgDNIjSTDJ5wZGjTc95L1QY/zlubjC0g==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.71.1.tgz",
+      "integrity": "sha512-nOmqErO1zd1wjvTbDscLZZ3fv5JPeQfaKuo0UCjYm7qPbpQcycp0l3nFZHxovjLjCetJ9IrLOADdznFYKV0f1A==",
       "dependencies": {
         "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
         "immutable": "^4.0.0",
         "rxjs": "^7.4.0",
-        "supports-color": "^8.1.1"
+        "supports-color": "^8.1.1",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "optionalDependencies": {
+        "sass-embedded-android-arm": "1.71.1",
+        "sass-embedded-android-arm64": "1.71.1",
+        "sass-embedded-android-ia32": "1.71.1",
+        "sass-embedded-android-x64": "1.71.1",
+        "sass-embedded-darwin-arm64": "1.71.1",
+        "sass-embedded-darwin-x64": "1.71.1",
+        "sass-embedded-linux-arm": "1.71.1",
+        "sass-embedded-linux-arm64": "1.71.1",
+        "sass-embedded-linux-ia32": "1.71.1",
+        "sass-embedded-linux-musl-arm": "1.71.1",
+        "sass-embedded-linux-musl-arm64": "1.71.1",
+        "sass-embedded-linux-musl-ia32": "1.71.1",
+        "sass-embedded-linux-musl-x64": "1.71.1",
+        "sass-embedded-linux-x64": "1.71.1",
+        "sass-embedded-win32-ia32": "1.71.1",
+        "sass-embedded-win32-x64": "1.71.1"
+      }
+    },
+    "node_modules/sass-embedded-android-arm": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.71.1.tgz",
+      "integrity": "sha512-Pq6TlRg9lIYsZDo9XNQZnSg6grQKzBG3ssdv0W1SnYS1BzGKwbg8XnlUA/pVxK76BKEm8i+0DA4y8cZ8A3tmpw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-arm64": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.71.1.tgz",
+      "integrity": "sha512-a7wJ1MM6sBwcM/8vIvvnwc9spoeNimNeXZpN9baSV4Ylthmr4GkTYYtf96Z/XYLdG5KBgYlxMs5T3OgqafdUMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
       },
-      "optionalDependencies": {
-        "sass-embedded-darwin-arm64": "1.60.0",
-        "sass-embedded-darwin-x64": "1.60.0",
-        "sass-embedded-linux-arm": "1.60.0",
-        "sass-embedded-linux-arm64": "1.60.0",
-        "sass-embedded-linux-ia32": "1.60.0",
-        "sass-embedded-linux-x64": "1.60.0",
-        "sass-embedded-win32-ia32": "1.60.0",
-        "sass-embedded-win32-x64": "1.60.0"
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-ia32": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.71.1.tgz",
+      "integrity": "sha512-tn3WZNdKQtr/DSzl4cQIDZkTO3JuuMxPvM/T+U7gBFyhU62NyF5wvwBnuh+BN3iaMowfkSknzCZCjyJDwnkDjw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-x64": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.71.1.tgz",
+      "integrity": "sha512-l72Pqxfb/pArpOLyWsuL9s8ODWupRGATWTPwUT/GjVdSQJO/lQL5DopXb55Cwh2T7t2G10e+uXTEMKz0qngoWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.60.0.tgz",
-      "integrity": "sha512-vgHLlLo+HggvmDT60fwMDJjjSUBRp65yZBbaXNEigUjHCAt4ghQ0fsWmcyWRXX8yFAOVH3Ya8qtbUlkvE1e3qw==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.71.1.tgz",
+      "integrity": "sha512-3eZDAcJBwoG0Kyasa/EbaKt1Jn2y0GHvCd0Oas/VtMsYL+/6abiCO1l8YltdxER4jvuHUKE2Ow7J6T6sC+vVQQ==",
       "cpu": [
         "arm64"
       ],
@@ -3546,14 +3660,17 @@
       "os": [
         "darwin"
       ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.60.0.tgz",
-      "integrity": "sha512-K7uFEzL5CnzPh7uNscstd2v4NooTJoQyjd64z6y3MWb3ArCl57w4ig/QAzwnydJ2YgaJD2YYVQrokCHyu4tjOw==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.71.1.tgz",
+      "integrity": "sha512-/9FtMPVdQalhsRCD9opNIlZqJKe7veCjWsdj0J9utbc2bNCTYswXNQtC/jWJTjE9/gQ0+w5zwg9+fQzltdYh1w==",
       "cpu": [
         "x64"
       ],
@@ -3561,14 +3678,71 @@
       "os": [
         "darwin"
       ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.60.0.tgz",
-      "integrity": "sha512-bLefkjt6kaHI9XqxRd+xHPSiKd/Klx7aVOV7K68F4O4YQSIs1pvdryrj6XeHtAyuNckkBStyRruD+bRPwJ7LmQ==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.71.1.tgz",
+      "integrity": "sha512-l7NEn0gji6GTN+p00DP2zZl9SE501Zy5obTA3beiD6+vQy7lCEC6vpNi/ZrlC6eRmgY2OKSBB2lfW7KSej9Hkg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-arm64": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.71.1.tgz",
+      "integrity": "sha512-zUSmqeqcgTb3VjZggk9a9xB2ZGaAe/TYAi/vYRPNLY/f7dZSrsa9Ejo+LUm2aNl6V8hFzMz7BpoKsaRQJnb9GQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-ia32": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.71.1.tgz",
+      "integrity": "sha512-NvzSljfc/Kw9/0CSn91AsINV2nh8vxhFe2cKexPMwvAqv/etU84dJMfJejxPJ39PmMqT1KvC4G+Qt2+6Mpe7oQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-arm": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.71.1.tgz",
+      "integrity": "sha512-1O37K5EgSeQjCBizIF9xdZJw3mh5XYHOnsB4+65CLZg4ac84ragjFv9d9rYhwGs9QSgg1MoOv7VWnEIxQ8Pp9Q==",
       "cpu": [
         "arm"
       ],
@@ -3580,10 +3754,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.60.0.tgz",
-      "integrity": "sha512-VoN/aLHWnSNZbRR0eifsylrPBWzqQsG++J2qPbzvnuakRspaIRDCirw2QGFhksmyty5bn/syekKAIUUaCamBJQ==",
+    "node_modules/sass-embedded-linux-musl-arm64": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.71.1.tgz",
+      "integrity": "sha512-Agtf6BcYQ0mt+jVDcRcN7bDPrMAQOWMeX15NTlQH1rO8voObLo6ThVl2NUkiZyyVmu7a6YOrCxpGBVAK1cLGOg==",
       "cpu": [
         "arm64"
       ],
@@ -3595,12 +3769,27 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.60.0.tgz",
-      "integrity": "sha512-2XkIOT+7rNkjuDMugFASnbvwh9Fg48hZZh8kW4ZPGj1QxHtZNlGLXt0C/i0jAZUdjhhyjd9l+xUIxZj5/JClPg==",
+    "node_modules/sass-embedded-linux-musl-ia32": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.71.1.tgz",
+      "integrity": "sha512-Cd5sJkt70bSlYEXUSj9mPMKZLzDL8LGcBKUIfQRrcBKjmzD2Va2eLq4Zati9Xzt54unuDp4bAUUTyvQmjLzFmA==",
       "cpu": [
         "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-x64": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.71.1.tgz",
+      "integrity": "sha512-uVfYms/lf4QVSvtQXkSm+Bq3wVsvkRMI30ca82rRwpwebxSaTbUr+uLnskh8QvbyfsbMyrzZQU0SCrO3uCua1A==",
+      "cpu": [
+        "x64"
       ],
       "optional": true,
       "os": [
@@ -3611,9 +3800,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.60.0.tgz",
-      "integrity": "sha512-V0ZooknRIkS3lqn+3Yh2xrpfgd82A4n9PvzV/1KJWs4p5eJsapRIx/yGXHPFHfooHagN57kDWaFFdQYUfuYHrw==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.71.1.tgz",
+      "integrity": "sha512-7BXniYic16+MQx0InyH8OXburLPGMRYRWf0l/t/fRkNkUHWFl7NQPAX0yvj73c/PKOdaYEUY6isNB4OGUGtZHQ==",
       "cpu": [
         "x64"
       ],
@@ -3621,14 +3810,17 @@
       "os": [
         "linux"
       ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.60.0.tgz",
-      "integrity": "sha512-pMNKxcysEVK4Dh27yLFNBAMqAKAJoVsl67lQ79LNrlZIVlIIwo/s1ajvImbf2srhWzizDJ1irxH2oBpF0kvxEA==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.71.1.tgz",
+      "integrity": "sha512-ZDhL6hvekeKDkZ1wUj6wN0thrB/7wOO8HaQoagk+pKaHoa0Py7OLR/m9mQM8S13mZpUQduNsznmXV1fOss4GOg==",
       "cpu": [
         "ia32"
       ],
@@ -3636,21 +3828,28 @@
       "os": [
         "win32"
       ],
+      "bin": {
+        "sass": "dart-sass/sass.bat"
+      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.60.0.tgz",
-      "integrity": "sha512-vGPeil9FzxJhPnWZ0zMLrY+GTT/fAUDVrKWQoXTxPfc7EugngbrqZ1qwVIVVCOC5zXDULB6LixCLFS8ut9R3KA==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.71.1.tgz",
+      "integrity": "sha512-ecWP1TFUA9ujOuOTJfWC1iZsSZOdQy5OxIEHqoERxunyjwzkiTxfN8J7Y4bNQ5uwb4K0brxWyIM8Fq+UgDqcZA==",
       "cpu": [
+        "arm64",
         "x64"
       ],
       "optional": true,
       "os": [
         "win32"
       ],
+      "bin": {
+        "sass": "dart-sass/sass.bat"
+      },
       "engines": {
         "node": ">=14.0.0"
       }
@@ -4047,9 +4246,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4058,6 +4257,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
@@ -4065,7 +4268,7 @@
         "picocolors": "^1.0.0"
       },
       "bin": {
-        "browserslist-lint": "cli.js"
+        "update-browserslist-db": "cli.js"
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
@@ -4079,6 +4282,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -4204,22 +4412,23 @@
       }
     },
     "@18f/identity-build-sass": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@18f/identity-build-sass/-/identity-build-sass-1.1.0.tgz",
-      "integrity": "sha512-nJeNQB+8tiQsvc6oh7UON1EsRK1MTuc9n5bMS9MIS2Mxa6mKkZDSGBdSR2TINAEdgQLlLlDOziRNTez4Um29jg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-build-sass/-/identity-build-sass-3.0.0.tgz",
+      "integrity": "sha512-GcSvtqai+8VO5jAAklx+pkzQEeYwgyMswY+752VrCQJ2zcfHy+VxMmYHJAEJ7+lKzcD/KhqSHkzwypMzcUtrVg==",
       "requires": {
-        "browserslist": "^4.21.5",
+        "@aduth/is-dependency": "^1.0.0",
+        "browserslist": "^4.22.3",
         "chokidar": "^3.5.3",
-        "lightningcss": "^1.16.1",
-        "sass-embedded": "^1.56.1"
+        "lightningcss": "^1.23.0",
+        "sass-embedded": "^1.70.0"
       }
     },
     "@18f/identity-design-system": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.1.0.tgz",
-      "integrity": "sha512-/DChj/p9hju15HMQCtukId2POIhHo25SjZzKh11bklkTICLOBEpPc1GRIkWUIDv5WU/N5DtX1saFafqs+HKnEA==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-8.1.2.tgz",
+      "integrity": "sha512-EvhnRvqOWmvjAdV2EedvSeoiN55RFA4RqAIsPTScw1N6QstbXEzJmDA242k3X81nf6Kd1yRFKxrKxNdl1CbmDQ==",
       "requires": {
-        "@uswds/uswds": "^3.4.1"
+        "@uswds/uswds": "^3.7.1"
       }
     },
     "@aashutoshrathi/word-wrap": {
@@ -4227,6 +4436,11 @@
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
+    },
+    "@aduth/is-dependency": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aduth/is-dependency/-/is-dependency-1.0.0.tgz",
+      "integrity": "sha512-1CJwTd6B6XDb6HETcHMwjRmQLQi2FgjM1rYUO6wf1yizKVPC9V66vmvVCtgePMzWmhsLqdhOPLWt+fNvG46FoA=="
     },
     "@babel/runtime": {
       "version": "7.23.2",
@@ -4239,9 +4453,9 @@
       }
     },
     "@bufbuild/protobuf": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.2.0.tgz",
-      "integrity": "sha512-MBVuQMOBHxgGnZ9XCUIi8WOy5O/T4ma3TduCRhRvndv3UDbG9cHgd8h6nOYSGyBYPEvXf1z9nTwhp8mVIDbq2g=="
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.7.2.tgz",
+      "integrity": "sha512-i5GE2Dk5ekdlK1TR7SugY4LWRrKSfb5T1Qn4unpIMbfxoeGKERKQ59HG3iYewacGD10SR7UzevfPnh6my4tNmQ=="
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -4357,11 +4571,11 @@
       "dev": true
     },
     "@uswds/uswds": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.4.1.tgz",
-      "integrity": "sha512-eLYbWUqf9eWUa2P6CO3ckIjtQyM3AylrIOHxN5gYG3P62TDd3FzRDyoACfvOe6CNk0w0PqXWJnuPzxpNoOgWNA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.7.1.tgz",
+      "integrity": "sha512-32u2S50bf5dwIujebqL+f1Jgx2rmRrpxcaccSZzdo3Qv9HaDUdcmeavlrxHqN30edHc7p8kRPjvjevOmOJKB7w==",
       "requires": {
-        "classlist-polyfill": "1.0.3",
+        "classlist-polyfill": "1.2.0",
         "object-assign": "4.1.1",
         "receptor": "1.0.0",
         "resolve-id-refs": "0.1.0"
@@ -4606,14 +4820,14 @@
       }
     },
     "browserslist": {
-      "version": "4.21.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
-      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001449",
-        "electron-to-chromium": "^1.4.284",
-        "node-releases": "^2.0.8",
-        "update-browserslist-db": "^1.0.10"
+        "caniuse-lite": "^1.0.30001587",
+        "electron-to-chromium": "^1.4.668",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
       }
     },
     "buffer-builder": {
@@ -4648,9 +4862,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001473",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz",
-      "integrity": "sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg=="
+      "version": "1.0.30001589",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001589.tgz",
+      "integrity": "sha512-vNQWS6kI+q6sBlHbh71IIeC+sRwK2N3EDySc/updIGhIee2x5z00J4c1242/5/d6EpEMdOnk/m+6tuk4/tcsqg=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -4689,9 +4903,9 @@
       }
     },
     "classlist-polyfill": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.0.3.tgz",
-      "integrity": "sha512-bDLDUsSg5LYFWsc2hphtG6ulyaCFSupdEBU3wxNECKWHnyPVvY8EB9Wbt9DzWkstWclFZhDaZK/VnEK/DmqE/Q=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ=="
     },
     "color-convert": {
       "version": "2.0.1",
@@ -4825,9 +5039,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.348",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.348.tgz",
-      "integrity": "sha512-gM7TdwuG3amns/1rlgxMbeeyNoBFPa+4Uu0c7FeROWh4qWmvSOnvcslKmWy51ggLKZ2n/F/4i2HJ+PVNxH9uCQ=="
+      "version": "1.4.680",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.680.tgz",
+      "integrity": "sha512-4nToZ5jlPO14W82NkF32wyjhYqQByVaDmLy4J2/tYcAbJfgO2TKJC780Az1V13gzq4l73CJ0yuyalpXvxXXD9A=="
     },
     "element-closest": {
       "version": "2.0.2",
@@ -4943,9 +5157,9 @@
       }
     },
     "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA=="
     },
     "escape-string-regexp": {
       "version": "4.0.0",
@@ -5574,9 +5788,9 @@
       "dev": true
     },
     "immutable": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
-      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg=="
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
+      "integrity": "sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -6001,67 +6215,74 @@
       }
     },
     "lightningcss": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.19.0.tgz",
-      "integrity": "sha512-yV5UR7og+Og7lQC+70DA7a8ta1uiOPnWPJfxa0wnxylev5qfo4P+4iMpzWAdYWOca4jdNQZii+bDL/l+4hUXIA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.23.0.tgz",
+      "integrity": "sha512-SEArWKMHhqn/0QzOtclIwH5pXIYQOUEkF8DgICd/105O+GCgd7jxjNod/QPnBCSWvpRHQBGVz5fQ9uScby03zA==",
       "requires": {
         "detect-libc": "^1.0.3",
-        "lightningcss-darwin-arm64": "1.19.0",
-        "lightningcss-darwin-x64": "1.19.0",
-        "lightningcss-linux-arm-gnueabihf": "1.19.0",
-        "lightningcss-linux-arm64-gnu": "1.19.0",
-        "lightningcss-linux-arm64-musl": "1.19.0",
-        "lightningcss-linux-x64-gnu": "1.19.0",
-        "lightningcss-linux-x64-musl": "1.19.0",
-        "lightningcss-win32-x64-msvc": "1.19.0"
+        "lightningcss-darwin-arm64": "1.23.0",
+        "lightningcss-darwin-x64": "1.23.0",
+        "lightningcss-freebsd-x64": "1.23.0",
+        "lightningcss-linux-arm-gnueabihf": "1.23.0",
+        "lightningcss-linux-arm64-gnu": "1.23.0",
+        "lightningcss-linux-arm64-musl": "1.23.0",
+        "lightningcss-linux-x64-gnu": "1.23.0",
+        "lightningcss-linux-x64-musl": "1.23.0",
+        "lightningcss-win32-x64-msvc": "1.23.0"
       }
     },
     "lightningcss-darwin-arm64": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.19.0.tgz",
-      "integrity": "sha512-wIJmFtYX0rXHsXHSr4+sC5clwblEMji7HHQ4Ub1/CznVRxtCFha6JIt5JZaNf8vQrfdZnBxLLC6R8pC818jXqg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.23.0.tgz",
+      "integrity": "sha512-kl4Pk3Q2lnE6AJ7Qaij47KNEfY2/UXRZBT/zqGA24B8qwkgllr/j7rclKOf1axcslNXvvUdztjo4Xqh39Yq1aA==",
       "optional": true
     },
     "lightningcss-darwin-x64": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.19.0.tgz",
-      "integrity": "sha512-Lif1wD6P4poaw9c/4Uh2z+gmrWhw/HtXFoeZ3bEsv6Ia4tt8rOJBdkfVaUJ6VXmpKHALve+iTyP2+50xY1wKPw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.23.0.tgz",
+      "integrity": "sha512-KeRFCNoYfDdcolcFXvokVw+PXCapd2yHS1Diko1z1BhRz/nQuD5XyZmxjWdhmhN/zj5sH8YvWsp0/lPLVzqKpg==",
+      "optional": true
+    },
+    "lightningcss-freebsd-x64": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.23.0.tgz",
+      "integrity": "sha512-xhnhf0bWPuZxcqknvMDRFFo2TInrmQRWZGB0f6YoAsZX8Y+epfjHeeOIGCfAmgF0DgZxHwYc8mIR5tQU9/+ROA==",
       "optional": true
     },
     "lightningcss-linux-arm-gnueabihf": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.19.0.tgz",
-      "integrity": "sha512-P15VXY5682mTXaiDtbnLYQflc8BYb774j2R84FgDLJTN6Qp0ZjWEFyN1SPqyfTj2B2TFjRHRUvQSSZ7qN4Weig==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.23.0.tgz",
+      "integrity": "sha512-fBamf/bULvmWft9uuX+bZske236pUZEoUlaHNBjnueaCTJ/xd8eXgb0cEc7S5o0Nn6kxlauMBnqJpF70Bgq3zg==",
       "optional": true
     },
     "lightningcss-linux-arm64-gnu": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.19.0.tgz",
-      "integrity": "sha512-zwXRjWqpev8wqO0sv0M1aM1PpjHz6RVIsBcxKszIG83Befuh4yNysjgHVplF9RTU7eozGe3Ts7r6we1+Qkqsww==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.23.0.tgz",
+      "integrity": "sha512-RS7sY77yVLOmZD6xW2uEHByYHhQi5JYWmgVumYY85BfNoVI3DupXSlzbw+b45A9NnVKq45+oXkiN6ouMMtTwfg==",
       "optional": true
     },
     "lightningcss-linux-arm64-musl": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.19.0.tgz",
-      "integrity": "sha512-vSCKO7SDnZaFN9zEloKSZM5/kC5gbzUjoJQ43BvUpyTFUX7ACs/mDfl2Eq6fdz2+uWhUh7vf92c4EaaP4udEtA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.23.0.tgz",
+      "integrity": "sha512-cU00LGb6GUXCwof6ACgSMKo3q7XYbsyTj0WsKHLi1nw7pV0NCq8nFTn6ZRBYLoKiV8t+jWl0Hv8KkgymmK5L5g==",
       "optional": true
     },
     "lightningcss-linux-x64-gnu": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.19.0.tgz",
-      "integrity": "sha512-0AFQKvVzXf9byrXUq9z0anMGLdZJS+XSDqidyijI5njIwj6MdbvX2UZK/c4FfNmeRa2N/8ngTffoIuOUit5eIQ==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.23.0.tgz",
+      "integrity": "sha512-q4jdx5+5NfB0/qMbXbOmuC6oo7caPnFghJbIAV90cXZqgV8Am3miZhC4p+sQVdacqxfd+3nrle4C8icR3p1AYw==",
       "optional": true
     },
     "lightningcss-linux-x64-musl": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.19.0.tgz",
-      "integrity": "sha512-SJoM8CLPt6ECCgSuWe+g0qo8dqQYVcPiW2s19dxkmSI5+Uu1GIRzyKA0b7QqmEXolA+oSJhQqCmJpzjY4CuZAg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.23.0.tgz",
+      "integrity": "sha512-G9Ri3qpmF4qef2CV/80dADHKXRAQeQXpQTLx7AiQrBYQHqBjB75oxqj06FCIe5g4hNCqLPnM9fsO4CyiT1sFSQ==",
       "optional": true
     },
     "lightningcss-win32-x64-msvc": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.19.0.tgz",
-      "integrity": "sha512-C+VuUTeSUOAaBZZOPT7Etn/agx/MatzJzGRkeV+zEABmPuntv1zihncsi+AyGmjkkzq3wVedEy7h0/4S84mUtg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.23.0.tgz",
+      "integrity": "sha512-1rcBDJLU+obPPJM6qR5fgBUiCdZwZLafZM5f9kwjFLkb/UBNIzmae39uCSmh71nzPCTXZqHbvwu23OWnWEz+eg==",
       "optional": true
     },
     "locate-path": {
@@ -6150,9 +6371,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
-      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -6587,9 +6808,9 @@
       }
     },
     "rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -6618,71 +6839,128 @@
       }
     },
     "sass-embedded": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.60.0.tgz",
-      "integrity": "sha512-pTCcbAaymfRX0Zkc17fGAVRBX3PPnj0vmWg93oGpeP/IMncxa58s+OPgDNIjSTDJ5wZGjTc95L1QY/zlubjC0g==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.71.1.tgz",
+      "integrity": "sha512-nOmqErO1zd1wjvTbDscLZZ3fv5JPeQfaKuo0UCjYm7qPbpQcycp0l3nFZHxovjLjCetJ9IrLOADdznFYKV0f1A==",
       "requires": {
         "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
         "immutable": "^4.0.0",
         "rxjs": "^7.4.0",
-        "sass-embedded-darwin-arm64": "1.60.0",
-        "sass-embedded-darwin-x64": "1.60.0",
-        "sass-embedded-linux-arm": "1.60.0",
-        "sass-embedded-linux-arm64": "1.60.0",
-        "sass-embedded-linux-ia32": "1.60.0",
-        "sass-embedded-linux-x64": "1.60.0",
-        "sass-embedded-win32-ia32": "1.60.0",
-        "sass-embedded-win32-x64": "1.60.0",
-        "supports-color": "^8.1.1"
+        "sass-embedded-android-arm": "1.71.1",
+        "sass-embedded-android-arm64": "1.71.1",
+        "sass-embedded-android-ia32": "1.71.1",
+        "sass-embedded-android-x64": "1.71.1",
+        "sass-embedded-darwin-arm64": "1.71.1",
+        "sass-embedded-darwin-x64": "1.71.1",
+        "sass-embedded-linux-arm": "1.71.1",
+        "sass-embedded-linux-arm64": "1.71.1",
+        "sass-embedded-linux-ia32": "1.71.1",
+        "sass-embedded-linux-musl-arm": "1.71.1",
+        "sass-embedded-linux-musl-arm64": "1.71.1",
+        "sass-embedded-linux-musl-ia32": "1.71.1",
+        "sass-embedded-linux-musl-x64": "1.71.1",
+        "sass-embedded-linux-x64": "1.71.1",
+        "sass-embedded-win32-ia32": "1.71.1",
+        "sass-embedded-win32-x64": "1.71.1",
+        "supports-color": "^8.1.1",
+        "varint": "^6.0.0"
       }
     },
+    "sass-embedded-android-arm": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.71.1.tgz",
+      "integrity": "sha512-Pq6TlRg9lIYsZDo9XNQZnSg6grQKzBG3ssdv0W1SnYS1BzGKwbg8XnlUA/pVxK76BKEm8i+0DA4y8cZ8A3tmpw==",
+      "optional": true
+    },
+    "sass-embedded-android-arm64": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.71.1.tgz",
+      "integrity": "sha512-a7wJ1MM6sBwcM/8vIvvnwc9spoeNimNeXZpN9baSV4Ylthmr4GkTYYtf96Z/XYLdG5KBgYlxMs5T3OgqafdUMg==",
+      "optional": true
+    },
+    "sass-embedded-android-ia32": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.71.1.tgz",
+      "integrity": "sha512-tn3WZNdKQtr/DSzl4cQIDZkTO3JuuMxPvM/T+U7gBFyhU62NyF5wvwBnuh+BN3iaMowfkSknzCZCjyJDwnkDjw==",
+      "optional": true
+    },
+    "sass-embedded-android-x64": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.71.1.tgz",
+      "integrity": "sha512-l72Pqxfb/pArpOLyWsuL9s8ODWupRGATWTPwUT/GjVdSQJO/lQL5DopXb55Cwh2T7t2G10e+uXTEMKz0qngoWQ==",
+      "optional": true
+    },
     "sass-embedded-darwin-arm64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.60.0.tgz",
-      "integrity": "sha512-vgHLlLo+HggvmDT60fwMDJjjSUBRp65yZBbaXNEigUjHCAt4ghQ0fsWmcyWRXX8yFAOVH3Ya8qtbUlkvE1e3qw==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.71.1.tgz",
+      "integrity": "sha512-3eZDAcJBwoG0Kyasa/EbaKt1Jn2y0GHvCd0Oas/VtMsYL+/6abiCO1l8YltdxER4jvuHUKE2Ow7J6T6sC+vVQQ==",
       "optional": true
     },
     "sass-embedded-darwin-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.60.0.tgz",
-      "integrity": "sha512-K7uFEzL5CnzPh7uNscstd2v4NooTJoQyjd64z6y3MWb3ArCl57w4ig/QAzwnydJ2YgaJD2YYVQrokCHyu4tjOw==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.71.1.tgz",
+      "integrity": "sha512-/9FtMPVdQalhsRCD9opNIlZqJKe7veCjWsdj0J9utbc2bNCTYswXNQtC/jWJTjE9/gQ0+w5zwg9+fQzltdYh1w==",
       "optional": true
     },
     "sass-embedded-linux-arm": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.60.0.tgz",
-      "integrity": "sha512-bLefkjt6kaHI9XqxRd+xHPSiKd/Klx7aVOV7K68F4O4YQSIs1pvdryrj6XeHtAyuNckkBStyRruD+bRPwJ7LmQ==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.71.1.tgz",
+      "integrity": "sha512-l7NEn0gji6GTN+p00DP2zZl9SE501Zy5obTA3beiD6+vQy7lCEC6vpNi/ZrlC6eRmgY2OKSBB2lfW7KSej9Hkg==",
       "optional": true
     },
     "sass-embedded-linux-arm64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.60.0.tgz",
-      "integrity": "sha512-VoN/aLHWnSNZbRR0eifsylrPBWzqQsG++J2qPbzvnuakRspaIRDCirw2QGFhksmyty5bn/syekKAIUUaCamBJQ==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.71.1.tgz",
+      "integrity": "sha512-zUSmqeqcgTb3VjZggk9a9xB2ZGaAe/TYAi/vYRPNLY/f7dZSrsa9Ejo+LUm2aNl6V8hFzMz7BpoKsaRQJnb9GQ==",
       "optional": true
     },
     "sass-embedded-linux-ia32": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.60.0.tgz",
-      "integrity": "sha512-2XkIOT+7rNkjuDMugFASnbvwh9Fg48hZZh8kW4ZPGj1QxHtZNlGLXt0C/i0jAZUdjhhyjd9l+xUIxZj5/JClPg==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.71.1.tgz",
+      "integrity": "sha512-NvzSljfc/Kw9/0CSn91AsINV2nh8vxhFe2cKexPMwvAqv/etU84dJMfJejxPJ39PmMqT1KvC4G+Qt2+6Mpe7oQ==",
+      "optional": true
+    },
+    "sass-embedded-linux-musl-arm": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.71.1.tgz",
+      "integrity": "sha512-1O37K5EgSeQjCBizIF9xdZJw3mh5XYHOnsB4+65CLZg4ac84ragjFv9d9rYhwGs9QSgg1MoOv7VWnEIxQ8Pp9Q==",
+      "optional": true
+    },
+    "sass-embedded-linux-musl-arm64": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.71.1.tgz",
+      "integrity": "sha512-Agtf6BcYQ0mt+jVDcRcN7bDPrMAQOWMeX15NTlQH1rO8voObLo6ThVl2NUkiZyyVmu7a6YOrCxpGBVAK1cLGOg==",
+      "optional": true
+    },
+    "sass-embedded-linux-musl-ia32": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.71.1.tgz",
+      "integrity": "sha512-Cd5sJkt70bSlYEXUSj9mPMKZLzDL8LGcBKUIfQRrcBKjmzD2Va2eLq4Zati9Xzt54unuDp4bAUUTyvQmjLzFmA==",
+      "optional": true
+    },
+    "sass-embedded-linux-musl-x64": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.71.1.tgz",
+      "integrity": "sha512-uVfYms/lf4QVSvtQXkSm+Bq3wVsvkRMI30ca82rRwpwebxSaTbUr+uLnskh8QvbyfsbMyrzZQU0SCrO3uCua1A==",
       "optional": true
     },
     "sass-embedded-linux-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.60.0.tgz",
-      "integrity": "sha512-V0ZooknRIkS3lqn+3Yh2xrpfgd82A4n9PvzV/1KJWs4p5eJsapRIx/yGXHPFHfooHagN57kDWaFFdQYUfuYHrw==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.71.1.tgz",
+      "integrity": "sha512-7BXniYic16+MQx0InyH8OXburLPGMRYRWf0l/t/fRkNkUHWFl7NQPAX0yvj73c/PKOdaYEUY6isNB4OGUGtZHQ==",
       "optional": true
     },
     "sass-embedded-win32-ia32": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.60.0.tgz",
-      "integrity": "sha512-pMNKxcysEVK4Dh27yLFNBAMqAKAJoVsl67lQ79LNrlZIVlIIwo/s1ajvImbf2srhWzizDJ1irxH2oBpF0kvxEA==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.71.1.tgz",
+      "integrity": "sha512-ZDhL6hvekeKDkZ1wUj6wN0thrB/7wOO8HaQoagk+pKaHoa0Py7OLR/m9mQM8S13mZpUQduNsznmXV1fOss4GOg==",
       "optional": true
     },
     "sass-embedded-win32-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.60.0.tgz",
-      "integrity": "sha512-vGPeil9FzxJhPnWZ0zMLrY+GTT/fAUDVrKWQoXTxPfc7EugngbrqZ1qwVIVVCOC5zXDULB6LixCLFS8ut9R3KA==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.71.1.tgz",
+      "integrity": "sha512-ecWP1TFUA9ujOuOTJfWC1iZsSZOdQy5OxIEHqoERxunyjwzkiTxfN8J7Y4bNQ5uwb4K0brxWyIM8Fq+UgDqcZA==",
       "optional": true
     },
     "semver": {
@@ -6966,9 +7244,9 @@
       "dev": true
     },
     "update-browserslist-db": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
@@ -6982,6 +7260,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "homepage": "https://github.com/18F/identity-dev-docs#readme",
   "dependencies": {
-    "@18f/identity-build-sass": "^1.1.0",
-    "@18f/identity-design-system": "^7.1.0"
+    "@18f/identity-build-sass": "^3.0.0",
+    "@18f/identity-design-system": "^8.1.2"
   },
   "devDependencies": {
     "@18f/eslint-plugin-identity": "^2.0.0",


### PR DESCRIPTION
This Pull Request fixes the icons in the warning boxes. Currently the CSS on the `before` pseudo element has the styles 

```
height: 1rem;
width: 1rem;
content: "";
height: 2px;
background-image: url(../img/usa-icons/warning.svg);
background-position: 50%;
background-repeat: no-repeat;
background-size: 1rem 1rem;
display: block;
position: absolute;
top: .5625rem;
left: 1rem;
```

With `height: 2px` taking precedent over the `height: 1rem`. I'm re-adding the `height: 1rem` with higher precedent to "win."

I know we don't like to add CSS directly, but I can not find where the `height: 2px` is being added to the element's style.

Before:

<img width="292" alt="image" src="https://github.com/18F/identity-dev-docs/assets/2308626/9d877e6c-2def-4c8c-a7b6-9a1e92eeac5c">

After:

<img width="410" alt="image" src="https://github.com/18F/identity-dev-docs/assets/2308626/fe35b6e9-76bf-4900-9e48-0c10244a7304">


