### PR TITLE
fix references to "test app" in the Dashboard

### DIFF
--- a/_pages/production.md
+++ b/_pages/production.md
@@ -79,7 +79,7 @@ Before you can request deployment, you need to create a new and separate applica
 
 **When you have the components required, follow these steps to create your production configuration app:**
 
-1.  [Create a new app on the](https://dashboard.int.identitysandbox.gov/) Login.gov Partner Dashboard. Select “Apps” from the top right menu, then select the “Create a new test app” button.
+1.  [Create a new app on the](https://dashboard.int.identitysandbox.gov/) Login.gov Partner Dashboard. Select “Apps” from the top right menu, then select the “Create a new app” button.
 
 2. Select “YES” for production configuration - this configuration is for a production app.
 
@@ -101,7 +101,7 @@ Before you can request deployment, you need to create a new and separate applica
 
 11. Specify the sign-in, sign-up, and forgot password help text users will encounter in your app. This step is optional but encouraged to ensure better usability. Take a look at the [Partner Support Help Desk](https://zendesk.login.gov) for a good example of help text.    
 
-12. Once all fields are complete select the "Create test app" button. 
+12. Once all fields are complete select the "Create app" button. 
 
 If you encounter errors or have questions after completing these steps, please submit a technical support ticket through the [Partner Support Help Desk.]({{ site.baseurl}}/support/#contacting-partner-support)
 


### PR DESCRIPTION
Some time ago we removed "test app" in favor of just "app" when talking about integration configurations in the Dashboard. This PR aligns the instructions in the documentation with this change.