### PR TITLE
Fix example URL in risc_outgoing.yml

### DIFF
--- a/_data/risc_outgoing.yml
+++ b/_data/risc_outgoing.yml
@@ -228,7 +228,7 @@
   payload_schema:
     *iss_sub_schema
   example_payload: {
-    "https://schemas.login.gov/secevent/risc/event-type/mfa-limit-account-locked": {
+    "https://schemas.login.gov/secevent/risc/event-type/reproof-completed": {
       "subject": {
         "subject_type": "iss-sub",
         "iss": "https://idp.int.identitysandbox.gov",


### PR DESCRIPTION
The reproof-completed event was referencing the wrong URL in the example.


Original PR: https://github.com/GSA-TTS/identity-dev-docs/pull/599