### PR TITLE
chore: use single quotes consistently in individual state error YAML

### DIFF
--- a/assets/yaml/individual_state_error.yml
+++ b/assets/yaml/individual_state_error.yml
@@ -9,9 +9,9 @@ document:
   zipcode: '11364'
   dob: '1938-10-06'
   phone: +1 314-555-1212
-  state_id_number: "mvatimeout"
-  state_id_type: "drivers_license"
-  state_id_jurisdiction: "WA"
+  state_id_number: 'mvatimeout'
+  state_id_type: 'drivers_license'
+  state_id_jurisdiction: 'WA'
   state_id_expiration: '2030-01-01'
   state_id_issued: '2020-01-01'
   issuing_country_code: 'US'


### PR DESCRIPTION
hey y'all! 👋 

i ran into a couple unexpected errors today proofing a mock identity in the sandbox. i'm not positive that the double-quotes in your sample snippet were causing the problem but i figured it'd be nice to use single quotes consistently like you do in other similar files.