### PR TITLE
(#15) Convert checkbox bullets to normal bullets

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -48,7 +48,7 @@ sidenav:
       </button>
     </dt>
     <dd id="home-register-checklist" class="usa-accordion__content" hidden>
-      <ul class="usa-list list-style-checkbox">
+      <ul class="usa-list">
         <li>Inter-agency agreement application name</li>
         <li>Public-face, friendly application name</li>
         <li>Implementation protocols (SAML or Open ID Connect)</li>


### PR DESCRIPTION
# Relevant Ticket or Conversation:

https://gitlab.login.gov/lg-teams/FIE/developer-docs/-/issues/15

# Description

The homepage was using checkbox-style bullets (`list-style-checkbox`) for the registration checklist information. These have been converted to standard unordered list bullets to match the intended design.

<img width="1912" height="1181" alt="image" src="https://github.com/user-attachments/assets/ece0fe94-cec7-4d81-94e5-68ff7fbb18b3" />

# Steps to Reproduce:

- View the developer documentation homepage
- Expand the "Information you need to register your configuration" accordion
- Observe the bullet style on the list items

# Expected behavior: 

List items should display with standard bullet points.

# Current behavior: 

List items display with checkbox-style bullets due to the `list-style-checkbox` class.

# AC:

- Update to standard bullet list via `•`

# Engineering Checklist
Follow the [Engineering Checklist](https://docs.google.com/document/d/1rkCUC8_fssdg6-Mxn81tPG0CC_y_5PfBZGjyXvWewKE)