### PR TITLE
Emphasize best practices for public certificates

### DIFF
--- a/_includes/snippets/oidc/certificates.md
+++ b/_includes/snippets/oidc/certificates.md
@@ -1,8 +1,0 @@
-{% capture ssl %}
-```
-openssl req -nodes -x509 -days 365 -newkey rsa:2048 -keyout private.pem -out public.crt
-```
-{% endcapture %}
-<div markdown="1" data-example="ssl" class="markdown">
-{{ ssl | markdownify }}
-</div>

--- a/_pages/oidc/certificates.md
+++ b/_pages/oidc/certificates.md
@@ -24,6 +24,8 @@ sidenav:
 Login.gov's public key, used to verify signed JWTs (such as the `id_token`), is available in [JWK](https://tools.ietf.org/html/rfc7517){:class="usa-link--external"} format at the `/api/openid_connect/certs` endpoint.
 
 This public key is rotated periodically (on at least an annual basis). It is important to assume the `/api/openid_connect/certs` endpoint could contain multiple JWKs when rotating application signing keys. Be sure to use the JWK endpoint dynamically through [auto-discovery](/oidc/getting-started/#auto-discovery) rather than hardcoding the public key. This ensures that your application will not require manual intervention when the Login.gov public key is rotated.
+
+For your own public/private keypair used to sign your JWT, please refer to the  [Creating a public certificate](/testing/#creating-a-public-certificate) section of our Testing documentation.
 {% endcapture %}
 
 <div class="grid-row grid-gap">
@@ -31,11 +33,5 @@ This public key is rotated periodically (on at least an annual basis). It is imp
     {{ content | markdownify }}
      <a href="{{ '/oidc/logout/' | prepend: site.baseurl }}" class="usa-link margin-top-4 mobile:display-none desktop:display-block">Next step: Logout</a>
   </div>
-    <div class="usa-layout-docs__main code-snippet-column desktop:grid-col-4">
-      <section id="pkce" class="code-snippet-section">
-        <span class="code-button code-button__selected margin-left-2">OpenSSL Command</span>
-          {% include snippets/oidc/certificates.md %}
-      </section>
-    </div>
-      <a href="{{ '/oidc/logout/' | prepend: site.baseurl }}" class="usa-link mobile:display-block desktop:display-none margin-top-2">Next step: Logout</a>
+    <a href="{{ '/oidc/logout/' | prepend: site.baseurl }}" class="usa-link mobile:display-block desktop:display-none margin-top-2">Next step: Logout</a>
 </div>

--- a/_pages/oidc/getting-started.md
+++ b/_pages/oidc/getting-started.md
@@ -60,7 +60,7 @@ You are able to test authentication methods in real time with a testing account 
 
 If you chose to integrate your app using the OIDC private_key_jwt protocol, you will need to create a private key that will be used to sign your request to our token endpoint, and a corresponding public certificate that you will upload to your app in the Partner Portal. Login.gov will use your public certificate to verify the signature in your request.
 
-More details on how to create this public/private keypair are available in the [Creating a public certificate](https://developers.login.gov/testing/#creating-a-public-certificate) section of our Testing documentation.
+More details on how to create this public/private keypair are available in the [Creating a public certificate](/testing/#creating-a-public-certificate) section of our Testing documentation.
 
 
 ### Auto-discovery

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -63,6 +63,11 @@ Depending on your agency’s integration additional items may be needed:
 
 - **If this is an integration requesting identity proofed attributes, you must include a Failure to Proof URL.** Users will be redirected to this URL if they fail to complete the identity verification process. This page should communicate your agency and/or departments alternate methods of accessing your application.
 
+- A public certificate that adheres to these industry standard best practices:
+  - Expiration date of one year or less
+  - Positive serial number at least 16 characters in length
+  - Signed by a trusted Certificate Authority
+
 If you have questions after reviewing this page, submit a technical support ticket through the [Partner Support Help Desk]({{ site.baseurl}}/support/#contacting-partner-support). You will need a [Login.gov production account](https://secure.login.gov) to submit technical support tickets. Your Login.gov production account and Login.gov sandbox (test environment) accounts are separate.
 
 

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -51,8 +51,8 @@ Make sure you have the following items ready before you start the deployment pro
 
 -   You must include an agency logo for your application. [Learn more about our logo guidelines.](/user-experience/agency-logo/)
 
-- A public certificate that adheres to these industry standard best practices:
-  - Expiration date of one year or less
+- A public certificate that adheres to these standard best practices:
+  - Expiration date of 1 to 3 years depending on use and risk factors (see [NIST 800-57 Part 1 Rev. 5](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r5.pdf)). We recommend 1 year or less to be on the safe side.
   - Positive serial number at least 16 characters in length
   - Signed by a trusted Certificate Authority
 

--- a/_pages/production.md
+++ b/_pages/production.md
@@ -51,6 +51,11 @@ Make sure you have the following items ready before you start the deployment pro
 
 -   You must include an agency logo for your application. [Learn more about our logo guidelines.](/user-experience/agency-logo/)
 
+- A public certificate that adheres to these industry standard best practices:
+  - Expiration date of one year or less
+  - Positive serial number at least 16 characters in length
+  - Signed by a trusted Certificate Authority
+
 Depending on your agency’s integration additional items may be needed:
 
 - **If this is a SAML integration (not OpenID Connect), then please ensure that:**
@@ -62,11 +67,6 @@ Depending on your agency’s integration additional items may be needed:
         -   If you are using a service which does not support SAML encryption, then please submit a technical support ticket through the [Partner Support Help Desk](https://zendesk.login.gov) for further guidance.
 
 - **If this is an integration requesting identity proofed attributes, you must include a Failure to Proof URL.** Users will be redirected to this URL if they fail to complete the identity verification process. This page should communicate your agency and/or departments alternate methods of accessing your application.
-
-- A public certificate that adheres to these industry standard best practices:
-  - Expiration date of one year or less
-  - Positive serial number at least 16 characters in length
-  - Signed by a trusted Certificate Authority
 
 If you have questions after reviewing this page, submit a technical support ticket through the [Partner Support Help Desk]({{ site.baseurl}}/support/#contacting-partner-support). You will need a [Login.gov production account](https://secure.login.gov) to submit technical support tickets. Your Login.gov production account and Login.gov sandbox (test environment) accounts are separate.
 

--- a/_pages/testing.md
+++ b/_pages/testing.md
@@ -73,7 +73,7 @@ Login.gov does not manage user accounts. If you have lost access to a team:
 
 ### Creating a public certificate
 
-You can use the following OpenSSL command to generate a self-signed 2048-bit PEM-encoded public certificate for your testing/sandbox application (with a 1-year validity period). Self-signed certificates should be for testing/sandbox purposes only. We recommend using Certificate Authority (CA) issued certificates for your production integration.
+You can use the following OpenSSL command to generate a self-signed 2048-bit PEM-encoded public certificate for your testing/sandbox application (with a 1-year validity period). Self-signed certificates should be for testing/sandbox purposes only. **For security reasons, we highly recommend using Certificate Authority (CA) issued certificates for your production integration.**
 
 ```
 openssl req -nodes -x509 -days 365 -newkey rsa:2048 -keyout private.pem -out public.crt


### PR DESCRIPTION
After auditing our partners' public certs in production, I noticed that quite a few do not adhere to standard best practices. And just today, we had a partner who thought that the OpenSSL command in our OIDC Certificates
page was all they needed for their production config.

This PR aims to clarify those best practices by making the following improvements:

- Remove the OpenSSL command snippet from the OIDC Certificates page since that
page relates to the Login.gov cert, not the partner's cert
- Add a blurb in the OIDC Certificates page that links to the instructions for
generating the partner's public/private keypair
- In the instructions for generating a public/private keypair, emphasize that for production configs, the cert should be signed by a Certificate Authority
- Add a checklist item in the "Before Deployment" section for the three main best practices for public certificates
