### PR TITLE
Remove recommendation for CA-signed certificates

### DIFF
--- a/_pages/production.md
+++ b/_pages/production.md
@@ -51,10 +51,10 @@ Make sure you have the following items ready before you start the deployment pro
 
 -   You must include an agency logo for your application. [Learn more about our logo guidelines.](/user-experience/agency-logo/)
 
-- A public certificate that adheres to these standard best practices:
-  - Expiration date of 1 to 3 years depending on use and risk factors (see [NIST 800-57 Part 1 Rev. 5](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r5.pdf)). We recommend 1 year or less to be on the safe side.
+- A public certificate that adheres to these best practices:
+  - Expiration date of 1 to 3 years depending on use and risk factors (see [NIST 800-57 Part 1 Rev. 5](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r5.pdf)).
   - Positive serial number at least 16 characters in length
-  - Signed by a trusted Certificate Authority
+  - Minimum length of 2048 bits
 
 Depending on your agency’s integration additional items may be needed:
 

--- a/_pages/testing.md
+++ b/_pages/testing.md
@@ -73,7 +73,7 @@ Login.gov does not manage user accounts. If you have lost access to a team:
 
 ### Creating a public certificate
 
-You can use the following OpenSSL command to generate a self-signed 2048-bit PEM-encoded public certificate for your testing/sandbox application (with a 1-year validity period). Self-signed certificates should be for testing/sandbox purposes only. **For security reasons, we highly recommend using Certificate Authority (CA) issued certificates for your production integration.**
+You can use the following OpenSSL command to generate a self-signed 2048-bit PEM-encoded public certificate for your testing/sandbox application (with a 1-year validity period).
 
 ```
 openssl req -nodes -x509 -days 365 -newkey rsa:2048 -keyout private.pem -out public.crt


### PR DESCRIPTION
After internal discussion and internet research, we could not find compelling evidence to support our existing recommendation for CA-signed certificates for production integrations. However, we found a few sources stating that self-signed certificates are perfectly acceptable in the context of signing SAML or OIDC requests.

References:

- https://workos.com/blog/ca-signed-certificates-saml
- https://support.pingidentity.com/s/article/Do-I-need-a-trusted-CA-signed-certificate-for-SAML-signatures
- https://knowledge.exlibrisgroup.com/Alma/Knowledge_Articles/Benefits_and_Recommendations_for_Long-Term_Self-Signed_SAML_Certificates
- The SAML spec: https://docs.oasis-open.org/security/saml/Post2.0/sstc-metadata-iop-os.pdf
