### PR TITLE
add auth_time / AuthInstant attribute documentation

### DIFF
--- a/_includes/snippets/oidc/user-info/response.md
+++ b/_includes/snippets/oidc/user-info/response.md
@@ -20,7 +20,8 @@
   "phone_verified": true,
   "social_security_number": "111223333",
   "sub": "b2d2d115-1d7e-4579-b9d6-f8e84f4f56ca",
-  "verified_at": 1577854800
+  "verified_at": 1577854800,
+  "auth_time": 1577874300
 }
 ```
 {% endcapture %}

--- a/_pages/oidc/user-info.md
+++ b/_pages/oidc/user-info.md
@@ -45,6 +45,16 @@ The user info response will be a JSON object containing [user attributes]({{ sit
     </div>
     <div class="dev-doc-row grid-row">
       <div class="grid-col-5">
+        <h4>auth_time <span class="text-normal">(number)</span></h4>
+      </div>
+      <div class="grid-col-7">
+        <p>
+          The timestamp of the user's last authentication event (seconds since the Unix Epoc).
+        </p>
+      </div>
+    </div>
+    <div class="dev-doc-row grid-row">
+      <div class="grid-col-5">
         <h4>email_verified <span class="text-normal">(boolean)</span></h4>
       </div>
       <div class="grid-col-7">

--- a/_pages/saml/authentication.md
+++ b/_pages/saml/authentication.md
@@ -81,7 +81,7 @@ A proofed identity request at AAL2, with phishing resistent MFA, for email, phon
           <h4>RelayState</h4>
         </div>
         <div class="grid-col-7">
-          <p>If you need to pass any information about the request back to your application after the authentication process is complete (e.g. the path to direct the user to), you can include a RelayState query parameter with up to 80 bytes of information. This will be included in the response back to your application as per section 3.4.3 of the <a class="usa-link" href="https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf">SAML 2.0 bindings spec</a>.</p>
+          <p>If you need to pass any information about the request back to your application after the authentication process is complete (e.g. the path to direct the user to), you can include a RelayState query parameter with up to 80 bytes of information. This will be included in the response back to your application as per section 3.4.3 of the <a class="usa-link usa-link--external" href="https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf">SAML v2.0 bindings spec</a>.</p>
           <p><code class="language-plaintext highlighter-rouge">https://idp.int.identitysandbox.gov/api/saml/auth2023?SAMLRequest=${SAML_REQUEST}&amp;RelayState=${RELAY_STATE}</code></p>
         </div>
       </div>
@@ -116,6 +116,7 @@ A proofed identity request at AAL2, with phishing resistent MFA, for email, phon
     <h2 id="authentication-response">Authentication response</h2>
     <p>After the user authenticates, Login.gov will redirect and POST a form back to your registered Assertion Consumer Service URL:</p>
     <p>The SAMLResponse is a base64-encoded XML payload that contains encrypted data.</p>
+    <p>The response also includes the <code class="language-plaintext highlighter-rouge">AuthInstant</code> attribute, which specifies the time at which the authentication took place. (see the <a href="https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf" class="usa-link usa-link--external">SAML v2.0 core spec</a> for details)</p>
     <a href="{{ '/saml/logout/' | prepend: site.baseurl }}" class="usa-link margin-top-4 mobile:display-none desktop:display-block">Next step: Logout</a>
   </div>
   <div class="usa-layout-docs__main code-snippet-column desktop:grid-col-5">


### PR DESCRIPTION
Ticket: https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/work_items/112

This adds documentation for the `auth_time` OIDC attribute, and `AuthInstant` SAML attribute. Since these attributes are always sent, and don't have to be requested, and generally work a little differently (particularly for SAML), it made more sense to include them in the respective protocol sections instead of on the `/atributes` page.